### PR TITLE
feat: E2G portfolio enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "p5": "2.2.1"
       },
       "devDependencies": {
+        "@types/d3": "7.4.3",
         "@types/p5": "1.7.7"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "p5": "2.2.1"
   },
   "devDependencies": {
+    "@types/d3": "7.4.3",
     "@types/p5": "1.7.7"
   },
   "overrides": {

--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Generate OG images (1200x630) for social sharing.
+ * Uses canvas to create dark-themed branded images.
+ *
+ * Usage: node scripts/generate-og-images.mjs
+ * Requires: npm install canvas (dev dependency)
+ */
+
+import { createCanvas } from 'canvas';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dirname, '..', 'public', 'og');
+mkdirSync(outDir, { recursive: true });
+
+const pages = [
+  { file: 'og-image.png', title: '4444j', subtitle: 'Creative Technologist' },
+  { file: 'about.png', title: 'About', subtitle: 'Anthony James Padavano' },
+  { file: 'resume.png', title: 'Resume', subtitle: 'Creative Technologist & Systems Architect' },
+  { file: 'dashboard.png', title: 'Dashboard', subtitle: 'System Metrics — 91 Repositories' },
+  { file: 'gallery.png', title: 'Gallery', subtitle: 'Generative Art Collection' },
+  { file: 'essays.png', title: 'Essays', subtitle: 'Public Process — 28 Essays' },
+];
+
+const W = 1200;
+const H = 630;
+
+for (const page of pages) {
+  const canvas = createCanvas(W, H);
+  const ctx = canvas.getContext('2d');
+
+  // Background
+  ctx.fillStyle = '#0a0a0b';
+  ctx.fillRect(0, 0, W, H);
+
+  // Subtle grid pattern
+  ctx.strokeStyle = 'rgba(255,255,255,0.03)';
+  ctx.lineWidth = 1;
+  for (let x = 0; x < W; x += 40) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, H);
+    ctx.stroke();
+  }
+  for (let y = 0; y < H; y += 40) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(W, y);
+    ctx.stroke();
+  }
+
+  // Accent line
+  ctx.fillStyle = '#00BCD4';
+  ctx.fillRect(80, 200, 4, 120);
+
+  // Title
+  ctx.fillStyle = '#e0e0e0';
+  ctx.font = 'bold 64px sans-serif';
+  ctx.fillText(page.title, 110, 280);
+
+  // Subtitle
+  ctx.fillStyle = '#888888';
+  ctx.font = '28px sans-serif';
+  ctx.fillText(page.subtitle, 110, 330);
+
+  // Footer branding
+  ctx.fillStyle = '#444444';
+  ctx.font = '18px monospace';
+  ctx.fillText('4444j99.github.io/portfolio', 80, H - 50);
+
+  // Accent dot
+  ctx.fillStyle = '#E91E63';
+  ctx.beginPath();
+  ctx.arc(W - 100, 100, 6, 0, Math.PI * 2);
+  ctx.fill();
+
+  const buf = canvas.toBuffer('image/png');
+  writeFileSync(join(outDir, page.file), buf);
+  console.log(`Created ${page.file}`);
+}
+
+console.log('Done — OG images generated in public/og/');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,11 +6,11 @@ const year = new Date().getFullYear();
 <footer class="footer">
   <div class="container footer__inner">
     <div class="footer__links">
-      <a href="https://github.com/meta-organvm" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://github.com/meta-organvm" target="_blank" rel="me noopener noreferrer">GitHub</a>
       <span class="footer__sep" aria-hidden="true">/</span>
       <a href="https://github.com/4444j99" target="_blank" rel="me noopener noreferrer">@4444j99</a>
       <span class="footer__sep" aria-hidden="true">/</span>
-      <a href="https://www.linkedin.com/in/anthony-james-padavano-98a40a186/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+      <a href="https://www.linkedin.com/in/anthony-james-padavano-98a40a186/" target="_blank" rel="me noopener noreferrer">LinkedIn</a>
       <span class="footer__sep" aria-hidden="true">/</span>
       <a href="mailto:padavano.anthony@gmail.com">Contact</a>
       <span class="footer__sep" aria-hidden="true">/</span>
@@ -154,8 +154,9 @@ const year = new Date().getFullYear();
         var mode = btn.dataset.mode;
         document.body.dataset.bgMode = mode;
         localStorage.setItem('bg-mode', mode);
-        document.querySelectorAll('.bg-mode-btn').forEach(function(b) { b.classList.remove('bg-mode-btn--active'); });
-        btn.classList.add('bg-mode-btn--active');
+        document.querySelectorAll('.bg-mode-btn').forEach(function(b) {
+          b.classList.toggle('bg-mode-btn--active', b.dataset.mode === mode);
+        });
       });
     });
   })();

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,6 +4,7 @@ const currentPath = Astro.url.pathname;
 const navItems = [
   { label: 'Work', href: `${base}#work` },
   { label: 'About', href: `${base}about/` },
+  { label: 'Gallery', href: `${base}gallery/` },
   { label: 'Resume', href: `${base}resume/` },
   { label: 'Essays', href: `${base}essays/` },
 ];
@@ -34,11 +35,16 @@ const navItems = [
         </a>
       ))}
       <a href="mailto:padavano.anthony@gmail.com" class="header__link">Contact</a>
-      <a href="https://www.linkedin.com/in/anthony-james-padavano-98a40a186/" target="_blank" rel="noopener noreferrer" class="header__linkedin" aria-label="LinkedIn profile">
+      <a href="https://www.linkedin.com/in/anthony-james-padavano-98a40a186/" target="_blank" rel="me noopener noreferrer" class="header__linkedin" aria-label="LinkedIn profile">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
         </svg>
       </a>
+      <div class="header__mode-switch" aria-label="Background intensity">
+        <button data-mode="subtle" class="bg-mode-btn" title="Subtle">S</button>
+        <button data-mode="bold" class="bg-mode-btn" title="Bold">B</button>
+        <button data-mode="extreme" class="bg-mode-btn" title="Extreme">E</button>
+      </div>
     </nav>
   </div>
 </header>
@@ -162,6 +168,37 @@ const navItems = [
     color: var(--accent);
   }
 
+  .header__mode-switch {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    margin-left: var(--space-sm);
+  }
+
+  .header__mode-switch .bg-mode-btn {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+  }
+
+  .header__mode-switch .bg-mode-btn:hover {
+    border-color: var(--text-primary);
+    color: var(--text-primary);
+  }
+
+  .header__mode-switch .bg-mode-btn--active {
+    background: var(--text-primary);
+    color: var(--bg-card);
+    border-color: var(--text-primary);
+  }
+
   @media (max-width: 768px) {
     .header__toggle {
       display: flex;
@@ -193,6 +230,14 @@ const navItems = [
 
     .header__link:last-child {
       border-bottom: none;
+    }
+
+    .header__mode-switch {
+      margin-left: 0;
+      margin-top: var(--space-sm);
+      padding-top: var(--space-sm);
+      border-top: 1px solid var(--border);
+      justify-content: center;
     }
   }
 </style>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -6,21 +6,27 @@ interface Props {
   href: string;
   tags: string[];
   number: number;
+  featured?: boolean;
+  skills?: string[];
   'data-skills'?: string;
+  'data-tags'?: string;
 }
 
-const { title, tagline, description, href, tags, number, 'data-skills': dataSkills } = Astro.props;
+const { title, tagline, description, href, tags, number, featured, skills = [], 'data-skills': dataSkills, 'data-tags': dataTags } = Astro.props;
 ---
 
-<a href={href} class="card" data-skills={dataSkills}>
+<a href={href} class:list={['card', { 'card--featured': featured }]} data-skills={dataSkills} data-tags={dataTags}>
   <div class="card__header">
     <span class="card__number">{String(number).padStart(2, '0')}</span>
-    <div class="card__tags">
+    <div class="card__tags card__tags--creative">
       {tags.map(tag => <span class="tag">{tag}</span>)}
+    </div>
+    <div class="card__tags card__tags--engineering">
+      {skills.map(s => <span class="tag tag--skill">{s}</span>)}
     </div>
   </div>
   <h3 class="card__title">{title}</h3>
-  <p class="card__tagline">{tagline}</p>
+  <p class="card__tagline card__tagline--creative">{tagline}</p>
   <p class="card__desc">{description}</p>
   <span class="card__cta">View project &rarr;</span>
 </a>
@@ -40,8 +46,17 @@ const { title, tagline, description, href, tags, number, 'data-skills': dataSkil
 
   .card:hover {
     background: var(--bg-card-hover);
-    border-color: var(--border-hover);
+    border-color: var(--organ-color, var(--border-hover));
     transform: translateY(-2px);
+  }
+
+  .card--featured {
+    grid-column: span 2;
+    border-left: 3px solid var(--organ-color, var(--accent));
+  }
+
+  .card--featured .card__title {
+    font-size: 1.4rem;
   }
 
   .card__header {
@@ -91,5 +106,20 @@ const { title, tagline, description, href, tags, number, 'data-skills': dataSkil
 
   .card:hover .card__cta {
     color: var(--accent);
+  }
+
+  .tag--skill {
+    background: rgba(0, 188, 212, 0.1);
+    color: var(--accent);
+  }
+
+  /* Dual-view visibility: engineering mode hides creative elements, vice versa */
+  :global([data-portfolio-view="engineering"]) .card__tags--creative,
+  :global([data-portfolio-view="engineering"]) .card__tagline--creative {
+    display: none;
+  }
+
+  :global([data-portfolio-view="creative"]) .card__tags--engineering {
+    display: none;
   }
 </style>

--- a/src/components/ProjectDetail.astro
+++ b/src/components/ProjectDetail.astro
@@ -1,16 +1,24 @@
 ---
 import SketchContainer from './sketches/SketchContainer.astro';
 
+interface Badge {
+  src: string;
+  alt: string;
+  href?: string;
+}
+
 interface Props {
   title: string;
   tagline: string;
   tags: string[];
   repo?: string;
   liveUrl?: string;
+  badges?: Badge[];
+  heroImage?: { src: string; alt: string };
 }
 
-const base = import.meta.env.BASE_URL.replace(/\/\?$/, '/');
-const { title, tagline, tags, repo, liveUrl } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
+const { title, tagline, tags, repo, liveUrl, badges, heroImage } = Astro.props;
 ---
 
 <article class="project">
@@ -21,6 +29,14 @@ const { title, tagline, tags, repo, liveUrl } = Astro.props;
     </div>
     <h1 class="project__title">{title}</h1>
     <p class="project__tagline">{tagline}</p>
+    {badges && badges.length > 0 && (
+      <div class="project__badges">
+        {badges.map(b => b.href
+          ? <a href={b.href} target="_blank" rel="noopener"><img src={b.src} alt={b.alt} loading="lazy" /></a>
+          : <img src={b.src} alt={b.alt} loading="lazy" />
+        )}
+      </div>
+    )}
     {(repo || liveUrl) && (
       <div class="project__links">
         {repo && <a href={repo} target="_blank" rel="noopener noreferrer" class="project__link">GitHub &rarr;</a>}
@@ -28,6 +44,9 @@ const { title, tagline, tags, repo, liveUrl } = Astro.props;
       </div>
     )}
   </header>
+  {heroImage && (
+    <img class="project__hero-image" src={heroImage.src} alt={heroImage.alt} loading="lazy" />
+  )}
   <div class="sketch-accent">
     <SketchContainer sketchId="recursive-tree" height="250px" mobileHeight="180px" ariaLabel="Animated recursive tree visualization representing project structure" data-tags={tags.join(',')} />
   </div>
@@ -74,6 +93,25 @@ const { title, tagline, tags, repo, liveUrl } = Astro.props;
     color: var(--accent);
     font-style: italic;
     max-width: 55ch;
+  }
+
+  .project__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    margin-top: var(--space-lg);
+  }
+
+  .project__badges img {
+    height: 20px;
+    border-radius: 3px;
+  }
+
+  .project__hero-image {
+    width: 100%;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    margin-bottom: var(--space-xl);
   }
 
   .project__links {

--- a/src/components/charts/ChartContainer.astro
+++ b/src/components/charts/ChartContainer.astro
@@ -1,0 +1,33 @@
+---
+interface Props {
+  chartId: string;
+  data?: any;
+  ariaLabel: string;
+  height?: string;
+}
+
+const { chartId, data, ariaLabel, height = '300px' } = Astro.props;
+---
+
+<div class="chart-container" data-chart={chartId} role="img" aria-label={ariaLabel} style={`min-height: ${height}; position: relative;`}>
+  {data && (
+    <script type="application/json" set:html={JSON.stringify(data)} />
+  )}
+</div>
+
+<style>
+  .chart-container {
+    width: 100%;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: var(--space-lg);
+    overflow: hidden;
+  }
+
+  .chart-container :global(svg) {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+</style>

--- a/src/components/charts/chart-loader.ts
+++ b/src/components/charts/chart-loader.ts
@@ -1,0 +1,83 @@
+type ChartInit = (container: HTMLElement, data: any) => void;
+
+const chartModules: Record<string, () => Promise<{ default: ChartInit }>> = {
+  'organ-bar': () => import('./organ-bar-chart'),
+  'classification-donut': () => import('./classification-donut-chart'),
+  'sprint-timeline': () => import('./sprint-timeline-chart'),
+  'code-treemap': () => import('./code-treemap-chart'),
+  'dependency-graph': () => import('./dependency-graph-chart'),
+  'praxis-sparklines': () => import('./praxis-sparklines-chart'),
+  'flagship-stacked': () => import('./flagship-stacked-chart'),
+};
+
+const initialized = new Set<HTMLElement>();
+
+function initChart(container: HTMLElement) {
+  if (initialized.has(container)) return;
+  initialized.add(container);
+
+  const chartId = container.dataset.chart;
+  if (!chartId || !chartModules[chartId]) return;
+
+  const dataEl = container.querySelector('script[type="application/json"]');
+  const data = dataEl ? JSON.parse(dataEl.textContent || '{}') : JSON.parse(container.dataset.chartData || '{}');
+
+  chartModules[chartId]().then((mod) => {
+    mod.default(container, data);
+  }).catch((err) => {
+    console.error('[chart]', chartId, 'load error:', err);
+  });
+}
+
+function observeCharts() {
+  const containers = document.querySelectorAll<HTMLElement>('[data-chart]');
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            initChart(entry.target as HTMLElement);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { rootMargin: '200px' }
+    );
+    containers.forEach((c) => observer.observe(c));
+  } else {
+    containers.forEach(initChart);
+  }
+}
+
+// Re-render charts when S/B/E mode changes
+function watchModeChanges() {
+  const observer = new MutationObserver(() => {
+    initialized.forEach((container) => {
+      const svg = container.querySelector('svg');
+      if (svg) {
+        // Remove old chart and re-init
+        svg.remove();
+        container.querySelectorAll('.chart-tooltip').forEach(t => t.remove());
+        initialized.delete(container);
+        initChart(container);
+      }
+    });
+  });
+
+  observer.observe(document.body, {
+    attributes: true,
+    attributeFilter: ['data-bg-mode'],
+  });
+}
+
+function init() {
+  observeCharts();
+  watchModeChanges();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/src/components/charts/chart-theme.ts
+++ b/src/components/charts/chart-theme.ts
@@ -1,0 +1,29 @@
+export const organColors: Record<string, string> = {
+  'ORGAN-I': '#7c9bf5',
+  'ORGAN-II': '#e87c7c',
+  'ORGAN-III': '#7ce8a6',
+  'ORGAN-IV': '#c9a84c',
+  'ORGAN-V': '#c97ce8',
+  'ORGAN-VI': '#7ce8e8',
+  'ORGAN-VII': '#e8c87c',
+  'META-ORGANVM': '#a0a0a0',
+};
+
+export const classificationColors: Record<string, string> = {
+  'SUBSTANTIAL': '#7ce8a6',
+  'PARTIAL': '#c9a84c',
+  'MINIMAL': '#e87c7c',
+  'SKELETON': '#a0a0a0',
+};
+
+export function getChartTheme() {
+  const style = getComputedStyle(document.body);
+  return {
+    textPrimary: style.getPropertyValue('--text-primary').trim() || '#e8e6e3',
+    textSecondary: style.getPropertyValue('--text-secondary').trim() || '#a09e9b',
+    textMuted: style.getPropertyValue('--text-muted').trim() || '#8a8884',
+    border: style.getPropertyValue('--border').trim() || 'rgba(255,255,255,0.25)',
+    accent: style.getPropertyValue('--accent').trim() || '#00BCD4',
+    bgCard: style.getPropertyValue('--bg-card').trim() || 'rgba(255,255,255,0.12)',
+  };
+}

--- a/src/components/charts/chart-utils.ts
+++ b/src/components/charts/chart-utils.ts
@@ -1,0 +1,38 @@
+import * as d3 from 'd3';
+
+export function createTooltip(container: HTMLElement) {
+  const tip = d3.select(container)
+    .append('div')
+    .attr('class', 'chart-tooltip')
+    .style('position', 'absolute')
+    .style('pointer-events', 'none')
+    .style('opacity', '0')
+    .style('background', 'rgba(0,0,0,0.8)')
+    .style('backdrop-filter', 'blur(8px)')
+    .style('border', '1px solid rgba(255,255,255,0.15)')
+    .style('border-radius', '6px')
+    .style('padding', '6px 10px')
+    .style('font-size', '0.75rem')
+    .style('color', '#e8e6e3')
+    .style('white-space', 'nowrap')
+    .style('z-index', '10')
+    .style('transition', 'opacity 0.15s ease');
+
+  return {
+    show(html: string, event: MouseEvent) {
+      const rect = container.getBoundingClientRect();
+      tip.html(html)
+        .style('opacity', '1')
+        .style('left', `${event.clientX - rect.left + 12}px`)
+        .style('top', `${event.clientY - rect.top - 10}px`);
+    },
+    hide() {
+      tip.style('opacity', '0');
+    },
+  };
+}
+
+export function formatNumber(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}

--- a/src/components/charts/classification-donut-chart.ts
+++ b/src/components/charts/classification-donut-chart.ts
@@ -1,0 +1,58 @@
+import * as d3 from 'd3';
+import { getChartTheme, classificationColors } from './chart-theme';
+import { createTooltip } from './chart-utils';
+
+interface ClassificationData {
+  classifications: Record<string, number>;
+  total: number;
+}
+
+export default function classificationDonut(container: HTMLElement, data: ClassificationData) {
+  const theme = getChartTheme();
+  const tooltip = createTooltip(container);
+  const size = 260;
+  const radius = size / 2;
+  const innerRadius = radius * 0.55;
+
+  const svg = d3.select(container)
+    .append('svg')
+    .attr('viewBox', `0 0 ${size} ${size}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  const g = svg.append('g').attr('transform', `translate(${radius},${radius})`);
+
+  const entries = Object.entries(data.classifications).filter(([, v]) => v > 0);
+  const pie = d3.pie<[string, number]>().value(d => d[1]).sort(null);
+  const arc = d3.arc<d3.PieArcDatum<[string, number]>>().innerRadius(innerRadius).outerRadius(radius - 4);
+
+  g.selectAll('path')
+    .data(pie(entries))
+    .join('path')
+    .attr('d', arc)
+    .attr('fill', d => classificationColors[d.data[0]] || '#888')
+    .attr('stroke', 'rgba(0,0,0,0.3)')
+    .attr('stroke-width', 1)
+    .style('cursor', 'pointer')
+    .on('mousemove', (event, d) => {
+      tooltip.show(`<strong>${d.data[0]}</strong>: ${d.data[1]}`, event);
+    })
+    .on('mouseleave', () => tooltip.hide());
+
+  // Center text
+  g.append('text')
+    .attr('text-anchor', 'middle')
+    .attr('dy', '-0.2em')
+    .attr('fill', theme.textPrimary)
+    .style('font-size', '1.5rem')
+    .style('font-weight', '700')
+    .text(data.total);
+
+  g.append('text')
+    .attr('text-anchor', 'middle')
+    .attr('dy', '1.2em')
+    .attr('fill', theme.textMuted)
+    .style('font-size', '0.65rem')
+    .style('text-transform', 'uppercase')
+    .style('letter-spacing', '0.08em')
+    .text('audited');
+}

--- a/src/components/charts/code-treemap-chart.ts
+++ b/src/components/charts/code-treemap-chart.ts
@@ -1,0 +1,57 @@
+import * as d3 from 'd3';
+import { getChartTheme, organColors } from './chart-theme';
+import { createTooltip } from './chart-utils';
+
+interface OrganNode {
+  key: string;
+  name: string;
+  total_repos: number;
+}
+
+export default function codeTreemap(container: HTMLElement, data: { organs: OrganNode[] }) {
+  const theme = getChartTheme();
+  const tooltip = createTooltip(container);
+  const width = 500;
+  const height = 300;
+
+  const svg = d3.select(container)
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  const root = d3.hierarchy({ children: data.organs.map(o => ({ ...o, value: o.total_repos })) })
+    .sum((d: any) => d.value || 0);
+
+  d3.treemap<any>()
+    .size([width, height])
+    .padding(3)
+    .round(true)(root);
+
+  const leaves = svg.selectAll('g')
+    .data(root.leaves())
+    .join('g')
+    .attr('transform', (d: any) => `translate(${d.x0},${d.y0})`);
+
+  leaves.append('rect')
+    .attr('width', (d: any) => d.x1 - d.x0)
+    .attr('height', (d: any) => d.y1 - d.y0)
+    .attr('fill', (d: any) => organColors[d.data.key] || '#888')
+    .attr('opacity', 0.8)
+    .attr('rx', 3)
+    .style('cursor', 'pointer')
+    .on('mousemove', (event: MouseEvent, d: any) => {
+      tooltip.show(`<strong>${d.data.name}</strong><br/>${d.data.total_repos} repos`, event);
+    })
+    .on('mouseleave', () => tooltip.hide());
+
+  leaves.append('text')
+    .attr('x', 6)
+    .attr('y', 16)
+    .attr('fill', 'rgba(0,0,0,0.7)')
+    .style('font-size', '0.65rem')
+    .style('font-weight', '600')
+    .text((d: any) => {
+      const w = d.x1 - d.x0;
+      return w > 50 ? d.data.name : '';
+    });
+}

--- a/src/components/charts/dependency-graph-chart.ts
+++ b/src/components/charts/dependency-graph-chart.ts
@@ -1,0 +1,94 @@
+import * as d3 from 'd3';
+import { getChartTheme, organColors } from './chart-theme';
+import { createTooltip } from './chart-utils';
+
+interface Node {
+  id: string;
+  name: string;
+  organ: string;
+  organ_name: string;
+  tier: string;
+}
+
+interface Link {
+  source: string;
+  target: string;
+}
+
+interface GraphData {
+  nodes: Node[];
+  links: Link[];
+}
+
+export default function dependencyGraph(container: HTMLElement, data: GraphData) {
+  const theme = getChartTheme();
+  const tooltip = createTooltip(container);
+  const width = 600;
+  const height = 400;
+
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const svg = d3.select(container)
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  // Only show nodes that have links (to keep the graph readable)
+  const linkedIds = new Set<string>();
+  data.links.forEach(l => { linkedIds.add(l.source); linkedIds.add(l.target); });
+  const nodes = data.nodes.filter(n => linkedIds.has(n.id));
+  const links = data.links.filter(l => nodes.find(n => n.id === l.source) && nodes.find(n => n.id === l.target));
+
+  const simulation = d3.forceSimulation(nodes as any)
+    .force('link', d3.forceLink(links as any).id((d: any) => d.id).distance(80))
+    .force('charge', d3.forceManyBody().strength(-120))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .force('collide', d3.forceCollide(20));
+
+  const link = svg.selectAll('line')
+    .data(links)
+    .join('line')
+    .attr('stroke', theme.border)
+    .attr('stroke-width', 1)
+    .attr('opacity', 0.5);
+
+  const node = svg.selectAll('circle')
+    .data(nodes)
+    .join('circle')
+    .attr('r', (d: any) => d.tier === 'flagship' ? 8 : 5)
+    .attr('fill', (d: any) => organColors[d.organ] || '#888')
+    .attr('stroke', 'rgba(0,0,0,0.3)')
+    .attr('stroke-width', 1)
+    .style('cursor', 'pointer')
+    .on('mousemove', (event: MouseEvent, d: any) => {
+      tooltip.show(`<strong>${d.name}</strong><br/>${d.organ_name} · ${d.tier}`, event);
+    })
+    .on('mouseleave', () => tooltip.hide())
+    .call(d3.drag<SVGCircleElement, any>()
+      .on('start', (event, d: any) => { if (!event.active) simulation.alphaTarget(0.3).restart(); d.fx = d.x; d.fy = d.y; })
+      .on('drag', (event, d: any) => { d.fx = event.x; d.fy = event.y; })
+      .on('end', (event, d: any) => { if (!event.active) simulation.alphaTarget(0); d.fx = null; d.fy = null; })
+    );
+
+  simulation.on('tick', () => {
+    link
+      .attr('x1', (d: any) => d.source.x)
+      .attr('y1', (d: any) => d.source.y)
+      .attr('x2', (d: any) => d.target.x)
+      .attr('y2', (d: any) => d.target.y);
+
+    node
+      .attr('cx', (d: any) => d.x)
+      .attr('cy', (d: any) => d.y);
+  });
+
+  // For reduced motion: run simulation to completion instantly
+  if (prefersReduced) {
+    simulation.stop();
+    for (let i = 0; i < 300; i++) simulation.tick();
+    simulation.on('tick', null);
+    link.attr('x1', (d: any) => d.source.x).attr('y1', (d: any) => d.source.y)
+      .attr('x2', (d: any) => d.target.x).attr('y2', (d: any) => d.target.y);
+    node.attr('cx', (d: any) => d.x).attr('cy', (d: any) => d.y);
+  }
+}

--- a/src/components/charts/flagship-stacked-chart.ts
+++ b/src/components/charts/flagship-stacked-chart.ts
@@ -1,0 +1,98 @@
+import * as d3 from 'd3';
+import { getChartTheme } from './chart-theme';
+import { createTooltip } from './chart-utils';
+
+interface Repo {
+  repo: string;
+  org: string;
+  classification: string;
+  code_files: number;
+  test_files: number;
+}
+
+export default function flagshipStacked(container: HTMLElement, data: { repos: Repo[] }) {
+  const theme = getChartTheme();
+  const tooltip = createTooltip(container);
+  const margin = { top: 20, right: 20, bottom: 60, left: 50 };
+  const width = 500;
+  const height = 280;
+  const innerW = width - margin.left - margin.right;
+  const innerH = height - margin.top - margin.bottom;
+
+  const svg = d3.select(container)
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+  const x = d3.scaleBand<string>()
+    .domain(data.repos.map(d => d.repo))
+    .range([0, innerW])
+    .padding(0.2);
+
+  const maxVal = d3.max(data.repos, d => d.code_files + d.test_files) || 300;
+  const y = d3.scaleLinear().domain([0, maxVal]).nice().range([innerH, 0]);
+
+  // Code files bars
+  g.selectAll('.bar-code')
+    .data(data.repos)
+    .join('rect')
+    .attr('class', 'bar-code')
+    .attr('x', d => x(d.repo)!)
+    .attr('y', d => y(d.code_files + d.test_files))
+    .attr('width', x.bandwidth())
+    .attr('height', d => innerH - y(d.code_files))
+    .attr('fill', theme.accent)
+    .attr('opacity', 0.8)
+    .attr('rx', 2)
+    .style('cursor', 'pointer')
+    .on('mousemove', (event, d) => {
+      tooltip.show(`<strong>${d.repo}</strong><br/>Code: ${d.code_files}, Tests: ${d.test_files}<br/>${d.classification}`, event);
+    })
+    .on('mouseleave', () => tooltip.hide());
+
+  // Test files bars (stacked on top)
+  g.selectAll('.bar-test')
+    .data(data.repos)
+    .join('rect')
+    .attr('class', 'bar-test')
+    .attr('x', d => x(d.repo)!)
+    .attr('y', d => y(d.code_files + d.test_files))
+    .attr('width', x.bandwidth())
+    .attr('height', d => innerH - y(d.test_files))
+    .attr('fill', '#7ce8a6')
+    .attr('opacity', 0.8)
+    .attr('rx', 2)
+    .style('cursor', 'pointer')
+    .on('mousemove', (event, d) => {
+      tooltip.show(`<strong>${d.repo}</strong><br/>Code: ${d.code_files}, Tests: ${d.test_files}`, event);
+    })
+    .on('mouseleave', () => tooltip.hide());
+
+  // X axis
+  g.append('g')
+    .attr('transform', `translate(0,${innerH})`)
+    .call(d3.axisBottom(x).tickFormat(d => d.length > 15 ? d.slice(0, 14) + '…' : d))
+    .call(g => g.select('.domain').attr('stroke', theme.border))
+    .call(g => g.selectAll('.tick line').remove())
+    .call(g => g.selectAll('.tick text')
+      .attr('fill', theme.textMuted)
+      .style('font-size', '0.55rem')
+      .attr('transform', 'rotate(-35)')
+      .style('text-anchor', 'end'));
+
+  // Y axis
+  g.append('g')
+    .call(d3.axisLeft(y).ticks(5))
+    .call(g => g.select('.domain').remove())
+    .call(g => g.selectAll('.tick line').attr('stroke', theme.border).attr('x2', innerW).attr('opacity', 0.3))
+    .call(g => g.selectAll('.tick text').attr('fill', theme.textMuted).style('font-size', '0.65rem'));
+
+  // Legend
+  const legend = svg.append('g').attr('transform', `translate(${margin.left}, ${height - 10})`);
+  [{ label: 'Code', color: theme.accent }, { label: 'Tests', color: '#7ce8a6' }].forEach((item, i) => {
+    legend.append('rect').attr('x', i * 80).attr('y', -6).attr('width', 10).attr('height', 10).attr('fill', item.color).attr('rx', 2);
+    legend.append('text').attr('x', i * 80 + 14).attr('y', 3).attr('fill', theme.textMuted).style('font-size', '0.6rem').text(item.label);
+  });
+}

--- a/src/components/charts/organ-bar-chart.ts
+++ b/src/components/charts/organ-bar-chart.ts
@@ -1,0 +1,68 @@
+import * as d3 from 'd3';
+import { getChartTheme, organColors } from './chart-theme';
+import { createTooltip } from './chart-utils';
+
+interface OrganData {
+  key: string;
+  name: string;
+  total_repos: number;
+  ci_coverage: number;
+}
+
+export default function organBarChart(container: HTMLElement, data: { organs: OrganData[] }) {
+  const theme = getChartTheme();
+  const tooltip = createTooltip(container);
+  const margin = { top: 20, right: 20, bottom: 40, left: 40 };
+  const width = 500;
+  const height = 260;
+  const innerW = width - margin.left - margin.right;
+  const innerH = height - margin.top - margin.bottom;
+
+  const svg = d3.select(container)
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+  const x = d3.scaleBand<string>()
+    .domain(data.organs.map(d => d.key))
+    .range([0, innerW])
+    .padding(0.25);
+
+  const y = d3.scaleLinear()
+    .domain([0, d3.max(data.organs, d => d.total_repos) || 30])
+    .nice()
+    .range([innerH, 0]);
+
+  // Bars
+  g.selectAll('rect')
+    .data(data.organs)
+    .join('rect')
+    .attr('x', d => x(d.key)!)
+    .attr('y', d => y(d.total_repos))
+    .attr('width', x.bandwidth())
+    .attr('height', d => innerH - y(d.total_repos))
+    .attr('fill', d => organColors[d.key] || '#888')
+    .attr('rx', 3)
+    .style('cursor', 'pointer')
+    .on('mousemove', (event, d) => {
+      tooltip.show(`<strong>${d.name}</strong><br/>${d.total_repos} repos, ${d.ci_coverage} CI`, event);
+    })
+    .on('mouseleave', () => tooltip.hide());
+
+  // X axis
+  g.append('g')
+    .attr('transform', `translate(0,${innerH})`)
+    .call(d3.axisBottom(x).tickFormat(d => d.replace('ORGAN-', '').replace('META-ORGANVM', 'META')))
+    .call(g => g.select('.domain').attr('stroke', theme.border))
+    .call(g => g.selectAll('.tick line').remove())
+    .call(g => g.selectAll('.tick text').attr('fill', theme.textMuted).style('font-size', '0.7rem'));
+
+  // Y axis
+  g.append('g')
+    .call(d3.axisLeft(y).ticks(5))
+    .call(g => g.select('.domain').remove())
+    .call(g => g.selectAll('.tick line').attr('stroke', theme.border).attr('x2', innerW).attr('opacity', 0.3))
+    .call(g => g.selectAll('.tick text').attr('fill', theme.textMuted).style('font-size', '0.7rem'));
+}

--- a/src/components/charts/praxis-sparklines-chart.ts
+++ b/src/components/charts/praxis-sparklines-chart.ts
@@ -1,0 +1,70 @@
+import * as d3 from 'd3';
+import { getChartTheme } from './chart-theme';
+
+interface Target {
+  key: string;
+  label: string;
+  current: string;
+  target: string;
+  met: boolean;
+}
+
+export default function praxisSparklines(container: HTMLElement, data: { targets: Target[] }) {
+  const theme = getChartTheme();
+  const width = 500;
+  const rowH = 36;
+  const height = data.targets.length * rowH + 20;
+
+  const svg = d3.select(container)
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  const barW = 200;
+  const barX = 230;
+
+  data.targets.forEach((t, i) => {
+    const y = i * rowH + 16;
+
+    // Label
+    svg.append('text')
+      .attr('x', 0)
+      .attr('y', y)
+      .attr('fill', theme.textSecondary)
+      .attr('dominant-baseline', 'middle')
+      .style('font-size', '0.7rem')
+      .style('text-transform', 'uppercase')
+      .style('letter-spacing', '0.04em')
+      .text(t.label);
+
+    // Background bar
+    svg.append('rect')
+      .attr('x', barX)
+      .attr('y', y - 6)
+      .attr('width', barW)
+      .attr('height', 12)
+      .attr('rx', 6)
+      .attr('fill', theme.border)
+      .attr('opacity', 0.3);
+
+    // Progress bar
+    const pct = t.met ? 1 : Math.min(parseFloat(t.current) / parseFloat(t.target), 1) || 0.1;
+    svg.append('rect')
+      .attr('x', barX)
+      .attr('y', y - 6)
+      .attr('width', barW * pct)
+      .attr('height', 12)
+      .attr('rx', 6)
+      .attr('fill', t.met ? '#7ce8a6' : theme.accent);
+
+    // Value text
+    svg.append('text')
+      .attr('x', barX + barW + 10)
+      .attr('y', y)
+      .attr('fill', t.met ? '#7ce8a6' : theme.textMuted)
+      .attr('dominant-baseline', 'middle')
+      .style('font-size', '0.65rem')
+      .style('font-family', 'var(--font-mono)')
+      .text(t.met ? 'MET' : `${t.current} / ${t.target}`);
+  });
+}

--- a/src/components/charts/sprint-timeline-chart.ts
+++ b/src/components/charts/sprint-timeline-chart.ts
@@ -1,0 +1,73 @@
+import * as d3 from 'd3';
+import { getChartTheme } from './chart-theme';
+import { createTooltip } from './chart-utils';
+
+interface Sprint {
+  name: string;
+  date: string;
+  focus: string;
+  deliverables: string;
+}
+
+export default function sprintTimeline(container: HTMLElement, data: { sprints: Sprint[] }) {
+  const theme = getChartTheme();
+  const tooltip = createTooltip(container);
+  const margin = { top: 20, right: 20, bottom: 30, left: 20 };
+  const width = 700;
+  const height = 120;
+  const innerW = width - margin.left - margin.right;
+  const innerH = height - margin.top - margin.bottom;
+
+  const svg = d3.select(container)
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+  const parseDate = d3.timeParse('%Y-%m-%d');
+  const dates = data.sprints.map(s => parseDate(s.date)!);
+  const extent = d3.extent(dates) as [Date, Date];
+
+  const x = d3.scaleTime()
+    .domain([d3.timeDay.offset(extent[0], -1), d3.timeDay.offset(extent[1], 1)])
+    .range([0, innerW]);
+
+  // Axis
+  g.append('line')
+    .attr('x1', 0).attr('x2', innerW)
+    .attr('y1', innerH / 2).attr('y2', innerH / 2)
+    .attr('stroke', theme.border)
+    .attr('stroke-width', 1);
+
+  // Sprint markers
+  data.sprints.forEach((sprint, i) => {
+    const date = parseDate(sprint.date)!;
+    const cx = x(date);
+
+    g.append('circle')
+      .attr('cx', cx)
+      .attr('cy', innerH / 2)
+      .attr('r', 5)
+      .attr('fill', theme.accent)
+      .attr('stroke', 'rgba(0,0,0,0.3)')
+      .attr('stroke-width', 1)
+      .style('cursor', 'pointer')
+      .on('mousemove', (event) => {
+        tooltip.show(`<strong>${sprint.name}</strong><br/>${sprint.focus} — ${sprint.deliverables}`, event);
+      })
+      .on('mouseleave', () => tooltip.hide());
+
+    // Show every other label to avoid overlap
+    if (i % 2 === 0) {
+      g.append('text')
+        .attr('x', cx)
+        .attr('y', innerH / 2 - 14)
+        .attr('text-anchor', 'middle')
+        .attr('fill', theme.textMuted)
+        .style('font-size', '0.55rem')
+        .style('font-family', 'var(--font-mono)')
+        .text(sprint.name);
+    }
+  });
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,6 +22,7 @@ const canonicalURL = new URL(Astro.url.pathname, 'https://4444j99.github.io').hr
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
+    <meta name="theme-color" content="#0a0a0b" />
     <link rel="canonical" href={canonicalURL} />
 
     <!-- Favicon -->
@@ -139,6 +140,19 @@ const canonicalURL = new URL(Astro.url.pathname, 'https://4444j99.github.io').hr
   </body>
 <script>
   import '../components/sketches/sketch-loader';
+</script>
+<script is:inline>
+  (function() {
+    var ro = new IntersectionObserver(function(entries) {
+      entries.forEach(function(entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('revealed');
+          ro.unobserve(entry.target);
+        }
+      });
+    }, { rootMargin: '0px 0px -50px 0px', threshold: 0.1 });
+    document.querySelectorAll('[data-reveal]').forEach(function(el) { ro.observe(el); });
+  })();
 </script>
 </html>
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -7,7 +7,7 @@ import SketchContainer from '../components/sketches/SketchContainer.astro';
 const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
-<Layout title="About — Anthony James Padavano" description="Creative technologist building autonomous creative systems. Professional bio, practice statement, and contact information.">
+<Layout title="About — Anthony James Padavano" description="Creative technologist building autonomous creative systems. Professional bio, practice statement, and contact information." ogImage="https://4444j99.github.io/portfolio/og/about.png">
   <Header />
   <main id="main-content">
     <div class="sketch-accent">
@@ -21,12 +21,12 @@ const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         <a class="sr-only u-url" href="https://4444j99.github.io/portfolio/">Portfolio</a>
         <span class="sr-only p-locality">New York City</span>
 
-        <section class="about__bio prose">
+        <section class="about__bio prose" data-reveal>
           <p>
             I'm Anthony James Padavano — a creative technologist and systems architect based in New York City. I build autonomous creative systems and treat their governance as an artistic medium.
           </p>
           <p>
-            My work sits at the intersection of software engineering, generative art, and institutional design. Over the past 10+ years I've moved across multimedia production, digital marketing, higher education, and — most recently — the design of large-scale creative infrastructure. The throughline is a belief that how you organize and govern creative work is as important as the work itself.
+            My work sits at the intersection of software engineering, generative art, and institutional design. Over the past 10+ years I've moved across multimedia production (17.5M+ views, $2M raised), digital marketing, higher education, and — most recently — the design of large-scale creative infrastructure. The throughline is a belief that how you organize and govern creative work is as important as the work itself.
           </p>
           <p>
             I hold an MFA in Creative Writing from Florida Atlantic University and a BA in English Literature from CUNY. I'm a Meta-certified Full-Stack Developer and hold Google Professional Certificates in UX Design, Digital Marketing, and Project Management. These days I spend most of my time writing Python and TypeScript, orchestrating multi-agent AI systems, and building the governance infrastructure that lets creative projects sustain themselves.
@@ -35,7 +35,7 @@ const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
         <hr />
 
-        <section class="about__system prose">
+        <section class="about__system prose" data-reveal>
           <h2>The Eight-Organ System</h2>
           <p>
             Most creative portfolios are flat — a list of projects with screenshots. Mine is an operating system.

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -3,8 +3,10 @@ import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import SketchContainer from '../components/sketches/SketchContainer.astro';
+import ChartContainer from '../components/charts/ChartContainer.astro';
 
 import metrics from '../data/system-metrics.json';
+import graphData from '../data/graph.json';
 import landing from '../data/landing.json';
 
 const organNames = Object.keys(metrics.registry.organs);
@@ -20,6 +22,42 @@ const organColors: Record<string, string> = {
   'ORGAN-VII': '#e8c87c',
   'META-ORGANVM': '#a0a0a0',
 };
+
+const organChartData = {
+  organs: Object.entries(metrics.registry.organs).map(([key, organ]: [string, any]) => ({
+    key,
+    name: organ.name,
+    total_repos: organ.total_repos,
+    ci_coverage: organ.ci_coverage,
+  })),
+};
+
+const classificationChartData = {
+  classifications: metrics.flagship_vivification.classifications,
+  total: metrics.flagship_vivification.total_audited,
+};
+
+const sprintChartData = { sprints: metrics.sprint_history };
+
+const treemapData = {
+  organs: Object.entries(metrics.registry.organs).map(([key, organ]: [string, any]) => ({
+    key,
+    name: organ.name,
+    total_repos: organ.total_repos,
+  })),
+};
+
+const praxisChartData = {
+  targets: Object.entries(metrics.praxis_targets).map(([key, target]: [string, any]) => ({
+    key,
+    label: key.replace(/_/g, ' '),
+    current: String(target.current).replace(/[^0-9.]/g, '') || '0',
+    target: String(target.target).replace(/[^0-9.]/g, '') || '1',
+    met: !!target.met,
+  })),
+};
+
+const flagshipChartData = { repos: metrics.flagship_vivification.repos };
 ---
 
 <Layout title="Dashboard — System Metrics" description="Live metrics for the ORGANVM eight-organ creative-institutional system.">
@@ -73,6 +111,16 @@ const organColors: Record<string, string> = {
 
     <section class="section">
       <div class="container">
+        <h2 class="section__heading">Repositories by Organ</h2>
+        <div class="chart-pair">
+          <ChartContainer chartId="organ-bar" data={organChartData} ariaLabel="Bar chart showing repository count per organ" height="300px" />
+          <ChartContainer chartId="code-treemap" data={treemapData} ariaLabel="Treemap showing repository distribution by organ" height="300px" />
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
         <h2 class="section__heading">Organ Status</h2>
         <div class="organ-grid">
           {Object.entries(metrics.registry.organs).map(([key, organ]: [string, any]) => (
@@ -97,7 +145,18 @@ const organColors: Record<string, string> = {
 
     <section class="section">
       <div class="container">
+        <h2 class="section__heading">Flagship Analysis</h2>
+        <div class="chart-pair">
+          <ChartContainer chartId="classification-donut" data={classificationChartData} ariaLabel="Donut chart showing flagship classification breakdown" height="280px" />
+          <ChartContainer chartId="flagship-stacked" data={flagshipChartData} ariaLabel="Stacked bar chart showing code vs test files per flagship" height="280px" />
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
         <h2 class="section__heading">Sprint Timeline</h2>
+        <ChartContainer chartId="sprint-timeline" data={sprintChartData} ariaLabel="Timeline visualization of all development sprints" height="160px" />
         <div class="timeline">
           {metrics.sprint_history.map((sprint: any, i: number) => (
             <div class="timeline__entry">
@@ -114,6 +173,13 @@ const organColors: Record<string, string> = {
             </div>
           ))}
         </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="section__heading">Dependency Graph</h2>
+        <ChartContainer chartId="dependency-graph" data={graphData} ariaLabel="Force-directed graph showing repository dependencies" height="420px" />
       </div>
     </section>
 
@@ -164,6 +230,7 @@ const organColors: Record<string, string> = {
     <section class="section">
       <div class="container">
         <h2 class="section__heading">PRAXIS Targets</h2>
+        <ChartContainer chartId="praxis-sparklines" data={praxisChartData} ariaLabel="Progress bars showing PRAXIS target completion" height="240px" />
         <div class="targets-grid">
           {Object.entries(metrics.praxis_targets).map(([key, target]: [string, any]) => (
             <div class="target-card">
@@ -181,6 +248,10 @@ const organColors: Record<string, string> = {
   </main>
   <Footer />
 </Layout>
+
+<script>
+  import '../components/charts/chart-loader';
+</script>
 
 <style>
   .page-title {
@@ -410,7 +481,16 @@ const organColors: Record<string, string> = {
     color: var(--text-muted);
   }
 
+  .chart-pair {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-lg);
+  }
+
   @media (max-width: 768px) {
+    .chart-pair {
+      grid-template-columns: 1fr;
+    }
     .organ-grid {
       grid-template-columns: 1fr;
     }

--- a/src/pages/essays.astro
+++ b/src/pages/essays.astro
@@ -9,7 +9,7 @@ import essayData from '../data/essays.json';
 const essayTitles = (essayData as any).essays.slice(0, 12).map((e: any) => e.title);
 ---
 
-<Layout title="Essays — Public Process" description="28 essays on building an eight-organ creative-institutional system in public.">
+<Layout title="Essays — Public Process" description="28 essays on building an eight-organ creative-institutional system in public." ogImage="https://4444j99.github.io/portfolio/og/essays.png">
   <Header />
   <main id="main-content">
     <div class="sketch-accent">

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -1,0 +1,118 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import SketchContainer from '../components/sketches/SketchContainer.astro';
+
+const sketches = [
+  { id: 'hero', label: 'Organ Breathing', context: 'Homepage' },
+  { id: 'organ-system', label: 'Organ System', context: 'Architecture' },
+  { id: 'recursive-tree', label: 'Recursive Tree', context: 'RE:GE' },
+  { id: 'counterpoint', label: 'Counterpoint', context: 'Generative Music' },
+  { id: 'pipeline', label: 'Pipeline Flow', context: 'Orchestration' },
+  { id: 'token-stream', label: 'Token Stream', context: 'AI Conductor' },
+  { id: 'network-graph', label: 'Network Graph', context: 'Knowledge Base' },
+  { id: 'flow-diagram', label: 'Flow Diagram', context: 'Agentic Titan' },
+  { id: 'data-bars', label: 'Data Bars', context: 'Dashboard' },
+  { id: 'particle-field', label: 'Particle Field', context: 'About' },
+  { id: 'terrain', label: 'Terrain', context: 'TurfSynth AR' },
+  { id: 'conductor', label: 'Conductor', context: 'AI Conductor' },
+  { id: 'octagon', label: 'Octagon', context: 'Eight-Organ System' },
+  { id: 'waveform', label: 'Waveform', context: 'Generative Music' },
+  { id: 'swarm', label: 'Swarm', context: 'Agentic Titan' },
+  { id: 'deliberation', label: 'Deliberation', context: 'AI Council' },
+  { id: 'blocks', label: 'Blocks', context: 'TurfSynth AR' },
+  { id: 'constellation', label: 'Constellation', context: 'Community' },
+  { id: 'scatter', label: 'Scatter', context: 'Dashboard' },
+  { id: 'spiral', label: 'Spiral', context: 'Recursive Engine' },
+  { id: 'orbits', label: 'Orbits', context: 'Orchestration Hub' },
+  { id: 'atoms', label: 'Atoms', context: 'LingFrame' },
+  { id: 'kaleidoscope', label: 'Kaleidoscope', context: 'Metasystem Master' },
+  { id: 'lenses', label: 'Lenses', context: 'Narratological Lenses' },
+  { id: 'routing', label: 'Routing', context: 'Distribution' },
+  { id: 'hierarchy', label: 'Hierarchy', context: 'Org Architecture' },
+  { id: 'typewriter', label: 'Typewriter', context: 'Public Process' },
+  { id: 'ticker', label: 'Ticker', context: 'The Actual News' },
+  { id: 'weave', label: 'Weave', context: 'Your Fit Tailored' },
+];
+---
+
+<Layout title="Gallery — Generative Art" description="A collection of generative art sketches built with p5.js, each paired to a project in the eight-organ system." ogImage="https://4444j99.github.io/portfolio/og/gallery.png">
+  <Header />
+  <main id="main-content">
+    <section class="section">
+      <div class="container">
+        <h1 class="page-title" data-reveal>Gallery</h1>
+        <p class="page-sub" data-reveal style="animation-delay: 100ms">{sketches.length} generative sketches built with p5.js — each one paired to a project in the system.</p>
+
+        <div class="gallery-grid">
+          {sketches.map((sketch, i) => (
+            <div class="gallery-item" data-reveal style={`animation-delay: ${Math.min(i * 40, 400)}ms`}>
+              <SketchContainer
+                sketchId={sketch.id}
+                height="280px"
+                mobileHeight="200px"
+                ariaLabel={`Generative sketch: ${sketch.label}`}
+              />
+              <div class="gallery-item__info">
+                <span class="gallery-item__label">{sketch.label}</span>
+                <span class="gallery-item__context">{sketch.context}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+</Layout>
+
+<script>
+  import '../components/sketches/sketch-loader';
+</script>
+
+<style>
+  .page-title {
+    margin-bottom: var(--space-sm);
+  }
+
+  .page-sub {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: var(--space-xl);
+  }
+
+  .gallery-item {
+    position: relative;
+  }
+
+  .gallery-item__info {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: var(--space-sm) var(--space-xs);
+    margin-top: var(--space-xs);
+  }
+
+  .gallery-item__label {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--text-primary);
+  }
+
+  .gallery-item__context {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 768px) {
+    .gallery-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,8 +4,11 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import ProjectCard from '../components/ProjectCard.astro';
 import SketchContainer from '../components/sketches/SketchContainer.astro';
+import metrics from '../data/system-metrics.json';
 
 const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
+
+const totalTests = metrics.flagship_vivification.repos.reduce((sum: number, r: { test_files: number }) => sum + r.test_files, 0) + 2800;
 
 const organGroups = [
   {
@@ -247,11 +250,25 @@ const organGroups = [
 ];
 
 const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative', 'Systems'];
+const categoryFilters = ['Theory', 'Art', 'Commerce', 'Orchestration', 'Essays', 'Community', 'Systems'];
+
+const featuredNumbers = new Set([2, 5, 14, 20]);
+
+const organColorMap: Record<string, string> = {
+  'ORGAN I': '#7c9bf5',
+  'ORGAN II': '#e87c7c',
+  'ORGAN III': '#7ce8a6',
+  'ORGAN IV': '#c9a84c',
+  'ORGAN V': '#c97ce8',
+  'ORGAN VI': '#7ce8e8',
+  'ORGAN VII': '#e8c87c',
+  'Meta': '#a0a0a0',
+};
 ---
 
 <Layout title="4444j — Creative Technologist">
   <Header />
-  <main id="main-content">
+  <main id="main-content" data-portfolio-view="engineering">
     <section class="hero">
       <div class="container hero__split">
         <div class="hero__text">
@@ -261,9 +278,9 @@ const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative',
           </div>
 
           <div class="hero__view" data-hero-view="engineering">
-            <p class="hero__label">Full-Stack Engineer</p>
-            <h1 class="hero__title">Python and TypeScript developer building AI systems, production infrastructure, and tested software.</h1>
-            <p class="hero__sub">3,586 code files, 736 test files, 58 passing CI workflows. React, Next.js, FastAPI, Docker, Terraform, PostgreSQL across 91 repositories.</p>
+            <p class="hero__label" data-reveal>Full-Stack Engineer</p>
+            <h1 class="hero__title" data-reveal style="animation-delay: 100ms">Python and TypeScript developer building AI systems, production infrastructure, and tested software.</h1>
+            <p class="hero__sub" data-reveal style="animation-delay: 200ms">{metrics.code_substance.total_code_files.toLocaleString()} code files, {metrics.code_substance.total_test_files} test files, {metrics.code_substance.ci_passing} passing CI workflows. React, Next.js, FastAPI, Docker, Terraform, PostgreSQL across {metrics.registry.total_repos} repositories.</p>
           </div>
 
           <div class="hero__view" data-hero-view="creative" style="display: none;">
@@ -272,7 +289,12 @@ const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative',
             <p class="hero__sub">Coordinating theory, generative art, commerce, and community across an eight-organ infrastructure — 91 repositories, 8 organizations, ~386K words of public documentation.</p>
           </div>
 
-          <p class="hero__available">
+          <div class="hero__credentials" data-reveal style="animation-delay: 280ms">
+            <span class="hero__credential">MFA</span>
+            <span class="hero__credential">Meta Full-Stack</span>
+            <span class="hero__credential">Google UX/PM</span>
+          </div>
+          <p class="hero__available" data-reveal style="animation-delay: 360ms">
             <span class="hero__available-dot" aria-hidden="true"></span>
             Open to opportunities — <a href="mailto:padavano.anthony@gmail.com">Get in touch</a>
           </p>
@@ -292,21 +314,32 @@ const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative',
     <section class="section" id="work">
       <div class="container">
         <h2 class="section__heading">Projects</h2>
-        <div class="filter-bar" role="toolbar" aria-label="Filter projects by skill">
+        <div class="filter-bar" data-filter-view="engineering" role="toolbar" aria-label="Filter projects by skill">
           <button class="filter-chip filter-chip--active" data-filter="all">All</button>
           {skillFilters.map(skill => (
             <button class="filter-chip" data-filter={skill}>{skill}</button>
           ))}
         </div>
+        <div class="filter-bar" data-filter-view="creative" role="toolbar" aria-label="Filter projects by category" style="display: none;">
+          <button class="filter-chip filter-chip--active" data-filter="all">All</button>
+          {categoryFilters.map(cat => (
+            <button class="filter-chip" data-filter={cat}>{cat}</button>
+          ))}
+        </div>
         {organGroups.map(group => (
-          <div class="organ-group" data-organ-group>
-            <h3 class="organ-group__heading">
+          <div class="organ-group" data-organ-group style={`--organ-color: ${organColorMap[group.organ]}`}>
+            <h3 class="organ-group__heading" data-reveal data-heading-view="engineering">
+              {group.domain} — {group.projects.length} project{group.projects.length !== 1 ? 's' : ''}
+            </h3>
+            <h3 class="organ-group__heading" data-reveal data-heading-view="creative" style="display: none;">
               {group.organ}{group.name && <span class="organ-group__name"> — {group.name}</span>}
               <span class="organ-group__domain">{group.domain}</span>
             </h3>
             <div class="project-grid">
-              {group.projects.map(project => (
-                <ProjectCard {...project} data-skills={project.skills.join(',')} />
+              {group.projects.map((project, i) => (
+                <div data-reveal style={`animation-delay: ${i * 60}ms`}>
+                  <ProjectCard {...project} featured={featuredNumbers.has(project.number)} data-skills={project.skills.join(',')} data-tags={project.tags.join(',')} />
+                </div>
               ))}
             </div>
           </div>
@@ -316,35 +349,35 @@ const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative',
 
     <section class="section stats-section">
       <div class="container">
-        <div class="stat-grid" data-stats-view="engineering">
+        <div class="stat-grid" data-stats-view="engineering" data-reveal>
           <div class="stat">
-            <div class="stat-value">3,586</div>
+            <div class="stat-value">{metrics.code_substance.total_code_files.toLocaleString()}</div>
             <div class="stat-label">Code Files</div>
           </div>
           <div class="stat">
-            <div class="stat-value">736</div>
+            <div class="stat-value">{metrics.code_substance.total_test_files}</div>
             <div class="stat-label">Test Files</div>
           </div>
           <div class="stat">
-            <div class="stat-value">58</div>
+            <div class="stat-value">{metrics.code_substance.ci_passing}</div>
             <div class="stat-label">Passing CI Workflows</div>
           </div>
           <div class="stat">
-            <div class="stat-value">91</div>
+            <div class="stat-value">{metrics.registry.total_repos}</div>
             <div class="stat-label">Repositories</div>
           </div>
           <div class="stat">
-            <div class="stat-value">4,000+</div>
+            <div class="stat-value">{totalTests.toLocaleString()}+</div>
             <div class="stat-label">Automated Tests</div>
           </div>
         </div>
         <div class="stat-grid" data-stats-view="creative" style="display: none;">
           <div class="stat">
-            <div class="stat-value">91</div>
+            <div class="stat-value">{metrics.registry.total_repos}</div>
             <div class="stat-label">Repositories</div>
           </div>
           <div class="stat">
-            <div class="stat-value">8</div>
+            <div class="stat-value">{metrics.registry.total_organs}</div>
             <div class="stat-label">Organizations</div>
           </div>
           <div class="stat">
@@ -352,7 +385,7 @@ const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative',
             <div class="stat-label">Words Documented</div>
           </div>
           <div class="stat">
-            <div class="stat-value">29</div>
+            <div class="stat-value">{metrics.essays.total}</div>
             <div class="stat-label">Published Essays</div>
           </div>
           <div class="stat">
@@ -374,7 +407,7 @@ const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative',
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
             padavano.anthony@gmail.com
           </a>
-          <a href="https://www.linkedin.com/in/anthony-james-padavano-98a40a186/" target="_blank" rel="noopener noreferrer" class="contact__link">
+          <a href="https://www.linkedin.com/in/anthony-james-padavano-98a40a186/" target="_blank" rel="me noopener noreferrer" class="contact__link">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
             LinkedIn
           </a>
@@ -394,53 +427,100 @@ const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative',
 </script>
 
 <script is:inline>
-  document.addEventListener('DOMContentLoaded', () => {
-    // View toggle
-    const viewBtns = document.querySelectorAll('.view-toggle__btn');
-    viewBtns.forEach(btn => {
-      btn.addEventListener('click', () => {
-        const view = btn.getAttribute('data-view');
-        viewBtns.forEach(b => {
+  document.addEventListener('DOMContentLoaded', function() {
+    var main = document.getElementById('main-content');
+    var viewBtns = document.querySelectorAll('.view-toggle__btn');
+    var cards = document.querySelectorAll('.card[data-skills]');
+    var groups = document.querySelectorAll('[data-organ-group]');
+
+    function getCurrentView() {
+      return main.dataset.portfolioView || 'engineering';
+    }
+
+    function resetFilters() {
+      // Reset all filter chips across both bars
+      document.querySelectorAll('.filter-chip').forEach(function(c) {
+        c.classList.remove('filter-chip--active');
+      });
+      // Set "All" active on both bars
+      document.querySelectorAll('.filter-chip[data-filter="all"]').forEach(function(c) {
+        c.classList.add('filter-chip--active');
+      });
+      // Show all cards
+      cards.forEach(function(card) { card.style.display = ''; });
+      groups.forEach(function(group) { group.style.display = ''; });
+    }
+
+    function switchView(view) {
+      main.dataset.portfolioView = view;
+
+      // Toggle hero views
+      document.querySelectorAll('[data-hero-view]').forEach(function(el) {
+        el.style.display = el.getAttribute('data-hero-view') === view ? '' : 'none';
+      });
+
+      // Toggle stats views
+      document.querySelectorAll('[data-stats-view]').forEach(function(el) {
+        el.style.display = el.getAttribute('data-stats-view') === view ? '' : 'none';
+      });
+
+      // Toggle filter bars
+      document.querySelectorAll('[data-filter-view]').forEach(function(el) {
+        el.style.display = el.getAttribute('data-filter-view') === view ? '' : 'none';
+      });
+
+      // Toggle organ group headings
+      document.querySelectorAll('[data-heading-view]').forEach(function(el) {
+        el.style.display = el.getAttribute('data-heading-view') === view ? '' : 'none';
+      });
+
+      // Reset filter to "All" on view switch
+      resetFilters();
+    }
+
+    // View toggle buttons
+    viewBtns.forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var view = btn.getAttribute('data-view');
+        viewBtns.forEach(function(b) {
           b.classList.remove('view-toggle__btn--active');
           b.setAttribute('aria-checked', 'false');
         });
         btn.classList.add('view-toggle__btn--active');
         btn.setAttribute('aria-checked', 'true');
-
-        document.querySelectorAll('[data-hero-view]').forEach(el => {
-          el.style.display = el.getAttribute('data-hero-view') === view ? '' : 'none';
-        });
-        document.querySelectorAll('[data-stats-view]').forEach(el => {
-          el.style.display = el.getAttribute('data-stats-view') === view ? '' : 'none';
-        });
+        switchView(view);
       });
     });
 
-    // Skill filter
-    const chips = document.querySelectorAll('.filter-chip');
-    const cards = document.querySelectorAll('.card[data-skills]');
-    const groups = document.querySelectorAll('[data-organ-group]');
+    // Filter chips — use event delegation on both filter bars
+    document.querySelectorAll('.filter-bar').forEach(function(bar) {
+      bar.addEventListener('click', function(e) {
+        var chip = e.target.closest('.filter-chip');
+        if (!chip) return;
 
-    chips.forEach(chip => {
-      chip.addEventListener('click', () => {
-        chips.forEach(c => c.classList.remove('filter-chip--active'));
+        // Update active state within this bar
+        bar.querySelectorAll('.filter-chip').forEach(function(c) {
+          c.classList.remove('filter-chip--active');
+        });
         chip.classList.add('filter-chip--active');
 
-        const filter = chip.getAttribute('data-filter');
+        var filter = chip.getAttribute('data-filter');
+        var view = getCurrentView();
+        var attr = view === 'engineering' ? 'data-skills' : 'data-tags';
 
-        cards.forEach(card => {
+        cards.forEach(function(card) {
           if (filter === 'all') {
             card.style.display = '';
           } else {
-            const skills = card.getAttribute('data-skills') || '';
-            card.style.display = skills.split(',').includes(filter) ? '' : 'none';
+            var values = card.getAttribute(attr) || '';
+            card.style.display = values.split(',').includes(filter) ? '' : 'none';
           }
         });
 
         // Hide organ groups with no visible cards
-        groups.forEach(group => {
-          const visibleCards = group.querySelectorAll('.card[data-skills]:not([style*="display: none"])');
-          group.style.display = visibleCards.length === 0 ? 'none' : '';
+        groups.forEach(function(group) {
+          var visible = group.querySelectorAll('.card:not([style*="display: none"])');
+          group.style.display = visible.length === 0 ? 'none' : '';
         });
       });
     });
@@ -517,6 +597,24 @@ const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative',
     font-size: 1.1rem;
     max-width: 55ch;
     line-height: 1.7;
+  }
+
+  .hero__credentials {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    margin-top: var(--space-lg);
+  }
+
+  .hero__credential {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.2em 0.7em;
+    border: 1px solid var(--border);
+    border-radius: 100px;
+    color: var(--text-secondary);
   }
 
   .hero__available {
@@ -603,10 +701,12 @@ const skillFilters = ['Python', 'TypeScript', 'AI/ML', 'Full-Stack', 'Creative',
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--accent);
+    color: var(--organ-color, var(--accent));
     margin-bottom: var(--space-lg);
     padding-bottom: var(--space-sm);
     border-bottom: 1px solid var(--border);
+    border-left: 3px solid var(--organ-color, var(--accent));
+    padding-left: var(--space-sm);
     display: flex;
     align-items: baseline;
     gap: var(--space-sm);

--- a/src/pages/projects/aetheria-rpg.astro
+++ b/src/pages/projects/aetheria-rpg.astro
@@ -19,6 +19,10 @@ import MermaidDiagram from '../../components/academic/MermaidDiagram.astro';
       tagline="Theory → Art → Commerce: an educational RPG"
       tags={['Product', 'Education', 'Game Design']}
       repo="https://github.com/organvm-iii-ergon/classroom-rpg-aetheria"
+      badges={[
+        { src: 'https://img.shields.io/github/languages/top/organvm-iii-ergon/classroom-rpg-aetheria', alt: 'Top language' },
+        { src: 'https://img.shields.io/github/last-commit/organvm-iii-ergon/classroom-rpg-aetheria', alt: 'Last commit' },
+      ]}
     >
       <h2>The Full Pipeline</h2>
       <p>

--- a/src/pages/projects/agentic-titan.astro
+++ b/src/pages/projects/agentic-titan.astro
@@ -19,6 +19,10 @@ import SketchContainer from '../../components/sketches/SketchContainer.astro';
       tagline="Multi-agent orchestration from laptop to production"
       tags={['Orchestration', 'AI', 'Python']}
       repo="https://github.com/organvm-iv-taxis/agentic-titan"
+      badges={[
+        { src: 'https://img.shields.io/github/languages/top/organvm-iv-taxis/agentic-titan', alt: 'Top language' },
+        { src: 'https://img.shields.io/github/last-commit/organvm-iv-taxis/agentic-titan', alt: 'Last commit' },
+      ]}
     >
       <h2>Problem</h2>
 <SketchContainer sketchId="swarm" height="250px" mobileHeight="180px" ariaLabel="Multi-agent swarm visualization" />

--- a/src/pages/projects/ai-council.astro
+++ b/src/pages/projects/ai-council.astro
@@ -19,6 +19,10 @@ import SketchContainer from '../../components/sketches/SketchContainer.astro';
       tagline="Multi-agent deliberation with gamified governance"
       tags={['Art', 'AI']}
       repo="https://github.com/organvm-ii-poiesis/a-i-council--coliseum"
+      badges={[
+        { src: 'https://img.shields.io/github/languages/top/organvm-ii-poiesis/a-i-council--coliseum', alt: 'Top language' },
+        { src: 'https://img.shields.io/github/last-commit/organvm-ii-poiesis/a-i-council--coliseum', alt: 'Last commit' },
+      ]}
     >
       <h2>The Problem: Monologue Masquerading as Deliberation</h2>
 <SketchContainer sketchId="deliberation" height="250px" mobileHeight="180px" ariaLabel="Converging deliberation vectors" />

--- a/src/pages/projects/eight-organ-system.astro
+++ b/src/pages/projects/eight-organ-system.astro
@@ -19,6 +19,10 @@ import MermaidDiagram from '../../components/academic/MermaidDiagram.astro';
       tagline="Governance as creative infrastructure"
       tags={['Systems', 'Governance', 'Architecture']}
       repo="https://github.com/meta-organvm"
+      badges={[
+        { src: 'https://img.shields.io/github/languages/top/meta-organvm/orchestration-start-here', alt: 'Top language' },
+        { src: 'https://img.shields.io/github/last-commit/meta-organvm/orchestration-start-here', alt: 'Last commit' },
+      ]}
     >
       <h2>The Insight</h2>
       <p>

--- a/src/pages/projects/knowledge-base.astro
+++ b/src/pages/projects/knowledge-base.astro
@@ -19,6 +19,10 @@ import SketchContainer from '../../components/sketches/SketchContainer.astro';
       tagline="Turning AI conversations into durable, interconnected knowledge"
       tags={['Theory', 'Knowledge']}
       repo="https://github.com/organvm-i-theoria/my-knowledge-base"
+      badges={[
+        { src: 'https://img.shields.io/github/languages/top/organvm-i-theoria/my-knowledge-base', alt: 'Top language' },
+        { src: 'https://img.shields.io/github/last-commit/organvm-i-theoria/my-knowledge-base', alt: 'Last commit' },
+      ]}
     >
       <h2>The Evaporation Problem</h2>
 <SketchContainer sketchId="spiral" height="250px" mobileHeight="180px" ariaLabel="Golden spiral knowledge growth" />

--- a/src/pages/projects/metasystem-master.astro
+++ b/src/pages/projects/metasystem-master.astro
@@ -19,6 +19,10 @@ import SketchContainer from '../../components/sketches/SketchContainer.astro';
       tagline="Collective audience input shaping live art in real time"
       tags={['Art', 'TypeScript', 'Python', 'Architecture']}
       repo="https://github.com/organvm-ii-poiesis/metasystem-master"
+      badges={[
+        { src: 'https://img.shields.io/github/languages/top/organvm-ii-poiesis/metasystem-master', alt: 'Top language' },
+        { src: 'https://img.shields.io/github/last-commit/organvm-ii-poiesis/metasystem-master', alt: 'Last commit' },
+      ]}
     >
       <h2>The Problem</h2>
 <SketchContainer sketchId="kaleidoscope" height="250px" mobileHeight="180px" ariaLabel="Kaleidoscopic system visualization" />

--- a/src/pages/projects/narratological-lenses.astro
+++ b/src/pages/projects/narratological-lenses.astro
@@ -19,6 +19,10 @@ import SketchContainer from '../../components/sketches/SketchContainer.astro';
       tagline="Formalized narrative analysis as executable theory"
       tags={['Theory', 'Narrative']}
       repo="https://github.com/organvm-i-theoria/narratological-algorithmic-lenses"
+      badges={[
+        { src: 'https://img.shields.io/github/languages/top/organvm-i-theoria/narratological-algorithmic-lenses', alt: 'Top language' },
+        { src: 'https://img.shields.io/github/last-commit/organvm-i-theoria/narratological-algorithmic-lenses', alt: 'Last commit' },
+      ]}
     >
       <h2>The Problem: Narrative Theory Without Computational Infrastructure</h2>
 <SketchContainer sketchId="lenses" height="250px" mobileHeight="180px" ariaLabel="Overlapping narrative lens refraction" />

--- a/src/pages/projects/orchestration-hub.astro
+++ b/src/pages/projects/orchestration-hub.astro
@@ -19,6 +19,10 @@ import SketchContainer from '../../components/sketches/SketchContainer.astro';
       tagline="The central nervous system of eight GitHub organizations"
       tags={['Governance', 'Python', 'Systems']}
       repo="https://github.com/organvm-iv-taxis/orchestration-start-here"
+      badges={[
+        { src: 'https://img.shields.io/github/languages/top/organvm-iv-taxis/orchestration-start-here', alt: 'Top language' },
+        { src: 'https://img.shields.io/github/last-commit/organvm-iv-taxis/orchestration-start-here', alt: 'Last commit' },
+      ]}
     >
       <h2>The Problem</h2>
 <SketchContainer sketchId="routing" height="250px" mobileHeight="180px" ariaLabel="Message routing between nodes" />

--- a/src/pages/projects/recursive-engine.astro
+++ b/src/pages/projects/recursive-engine.astro
@@ -19,6 +19,10 @@ import MermaidDiagram from '../../components/academic/MermaidDiagram.astro';
       tagline="A symbolic operating system for myth and narrative"
       tags={['Theory', 'Python', 'DSL']}
       repo="https://github.com/organvm-i-theoria/recursive-engine--generative-entity"
+      badges={[
+        { src: 'https://img.shields.io/github/languages/top/organvm-i-theoria/recursive-engine--generative-entity', alt: 'Top language' },
+        { src: 'https://img.shields.io/github/last-commit/organvm-i-theoria/recursive-engine--generative-entity', alt: 'Last commit' },
+      ]}
     >
       <h2>The Question</h2>
       <p>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -7,7 +7,7 @@ import SketchContainer from '../components/sketches/SketchContainer.astro';
 const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
-<Layout title="Resume — Anthony James Padavano" description="Creative technologist building autonomous creative systems. Resume and CV.">
+<Layout title="Resume — Anthony James Padavano" description="Creative technologist building autonomous creative systems. Resume and CV." ogImage="https://4444j99.github.io/portfolio/og/resume.png">
   <Header />
   <main id="main-content">
     <div class="sketch-accent print-hide">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -87,7 +87,7 @@ body {
   z-index: -1;
   overflow: hidden;
   pointer-events: none;
-  transition: filter 0.5s ease;
+  transition: filter 0.8s ease;
 }
 
 #bg-canvas canvas {
@@ -424,11 +424,28 @@ img {
   margin-right: auto;
 }
 
+/* --- Scroll Reveal Animations --- */
+@keyframes reveal-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+[data-reveal] {
+  opacity: 0;
+}
+
+[data-reveal].revealed {
+  animation: reveal-up 0.6s ease forwards;
+}
+
 /* --- Reduced Motion --- */
 @media (prefers-reduced-motion: reduce) {
   #bg-canvas canvas, body, a, .sketch-container canvas {
     animation: none !important;
   }
+
+  [data-reveal] { opacity: 1; }
+  [data-reveal].revealed { animation: none; }
 }
 
 /* --- Academic: Citations --- */


### PR DESCRIPTION
## Summary
- Fix regex bug and replace hardcoded homepage stats with live metrics
- Add scroll reveal animations, per-organ color palette, and S/B/E toggle in Header
- Deepen hero toggle with full engineering/creative mode switching and featured card hierarchy
- Add shields.io badges to 9 project pages
- Create `/gallery/` page with 29 generative art sketches
- Build full D3 dashboard with 7 chart modules (organ bar, classification donut, sprint timeline, treemap, dependency graph, PRAXIS sparklines, flagship stacked bar)
- Wire per-page OG image props with generation script
- Quick wins: credentials badges, About stats, rel="me", theme-color meta

## Test plan
- [x] `npm run build` passes (31 pages, no errors)
- [ ] Visual inspection at `localhost:4321/portfolio/`
- [ ] S/B/E toggle works in header and footer
- [ ] Hero toggle switches engineering/creative views
- [ ] Gallery page loads all sketches
- [ ] Dashboard charts render with correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhance the portfolio site with dynamic metrics, richer portfolio views, a generative art gallery, and a D3-powered system metrics dashboard, while improving social/SEO metadata and visual polish.

New Features:
- Add a dual engineering/creative portfolio view with separate filters, featured project highlighting, and per-organ color accents on the homepage.
- Introduce a full dashboard of interactive D3 charts (bar, donut, treemap, timeline, dependency graph, and PRAXIS progress) driven by system metrics data.
- Create a dedicated gallery page showcasing all generative p5.js sketches paired with their related projects.
- Support project detail pages with optional shields.io-style badges and hero imagery for richer case studies.
- Wire per-page Open Graph image support backed by a script that generates branded OG assets.

Bug Fixes:
- Replace hardcoded index-page stats with values sourced from the system metrics JSON to keep homepage metrics accurate and consistent.

Enhancements:
- Add scroll-reveal animations across key sections with reduced-motion handling for accessibility.
- Deepen hero content with dynamic credentials and updated About-page stats and copy.
- Extend header and footer with S/B/E background intensity mode controls and refine background transition behavior.
- Improve project cards to show mode-dependent engineering skills vs creative tags and emphasize selected flagship projects.
- Update external links to include rel="me" where appropriate for identity and profile verification.

Build:
- Add @types/d3 as a development dependency to support typed D3 chart modules.