### PR TITLE
feat(bento): Phase Ic — responsive polish and visual regression tests

### DIFF
--- a/src/__tests__/bento-visual.test.ts
+++ b/src/__tests__/bento-visual.test.ts
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const DIST = resolve(process.cwd(), 'dist');
+
+describe('bento grid structure', () => {
+	const indexPath = resolve(DIST, 'index.html');
+
+	it('dist/index.html exists', () => {
+		expect(existsSync(indexPath)).toBe(true);
+	});
+
+	it('has bento-grid section', () => {
+		const html = readFileSync(indexPath, 'utf8');
+		expect(html).toContain('class="bento-grid"');
+		expect(html).toContain('aria-label="Portfolio overview"');
+	});
+
+	it('has hero cell with name and stat pills', () => {
+		const html = readFileSync(indexPath, 'utf8');
+		expect(html).toContain('bento-cell--hero');
+		expect(html).toContain('Anthony James Padavano');
+		expect(html).toContain('stat-pill');
+	});
+
+	it('has 2 featured project cards with transition:name', () => {
+		const html = readFileSync(indexPath, 'utf8');
+		const featured = html.match(/bento-card--featured/g);
+		expect(featured?.length).toBe(2);
+		expect(html).toContain('data-astro-transition-scope');
+	});
+
+	it('has controls cell with view toggle and depth control', () => {
+		const html = readFileSync(indexPath, 'utf8');
+		expect(html).toContain('controls-cell');
+		expect(html).toContain('bento-view-toggle');
+		expect(html).toContain('data-shibui-control');
+	});
+
+	it('has persona cell with 4 persona links', () => {
+		const html = readFileSync(indexPath, 'utf8');
+		expect(html).toContain('persona-cell');
+		const personaLinks = html.match(/persona-cell__link/g);
+		expect(personaLinks?.length).toBeGreaterThanOrEqual(4);
+	});
+
+	it('has CTA cell', () => {
+		const html = readFileSync(indexPath, 'utf8');
+		expect(html).toContain('cta-cell');
+		expect(html).toContain('Start a conversation');
+	});
+
+	it('has see-all projects link', () => {
+		const html = readFileSync(indexPath, 'utf8');
+		expect(html).toContain('bento-card--see-all');
+	});
+
+	it('does NOT have old ProjectGrid or home-pair', () => {
+		const html = readFileSync(indexPath, 'utf8');
+		expect(html).not.toContain('project-grid');
+		expect(html).not.toContain('home-pair');
+		expect(html).not.toContain('organ-group__toggle');
+	});
+
+	it('has dual-view data attributes', () => {
+		const html = readFileSync(indexPath, 'utf8');
+		expect(html).toContain('data-hero-view="engineering"');
+		expect(html).toContain('data-hero-view="creative"');
+		expect(html).toContain('data-stats-view="engineering"');
+		expect(html).toContain('data-stats-view="creative"');
+	});
+});

--- a/src/data/quality-metrics.json
+++ b/src/data/quality-metrics.json
@@ -1,9 +1,9 @@
 {
-  "generated": "2026-03-27T21:23:28.189Z",
+  "generated": "2026-03-27T21:41:24.133Z",
   "tests": {
     "total": 289,
     "passed": 289,
-    "files": 34
+    "files": 35
   },
   "security": {
     "critical": 0,
@@ -1704,7 +1704,7 @@
   },
   "build": {
     "pages": 102,
-    "bundleFiles": 67
+    "bundleFiles": 66
   },
   "sources": {
     "tests": ".quality/vitest-report.json",

--- a/src/data/trust-vitals.json
+++ b/src/data/trust-vitals.json
@@ -26,8 +26,8 @@
       "approval": "Student evaluation approval rating across all teaching assignments"
     }
   },
-  "generatedAt": "2026-03-27T21:23:28.448Z",
-  "fingerprint": "AB88D898",
+  "generatedAt": "2026-03-27T21:41:24.446Z",
+  "fingerprint": "85D36BA3",
   "strikes": {
     "total": 2,
     "conversionRate": 0

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -535,6 +535,15 @@ a.bento-cell:focus-visible {
 	margin-top: var(--space-md);
 }
 
+@media (max-width: 767px) {
+	.stat-pills {
+		flex-wrap: nowrap;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		padding-bottom: var(--space-2xs);
+	}
+}
+
 .stat-pill {
 	display: inline-flex;
 	align-items: baseline;


### PR DESCRIPTION
## Summary

- Tablet: featured cards reset row span at 768-1023px
- Mobile: stat pills become horizontal scrollable row
- 10 new structural tests for bento grid HTML output
- Validates: hero, stats, featured cards, controls, personas, CTA, absence of old components
- No `data-reveal` on bento cells (above-fold, no scroll trigger needed)

## Part of

Alpha-to-Omega roadmap Phase I (Bento Grid Homepage). Spec: `docs/superpowers/specs/2026-03-26-alpha-omega-roadmap-design.md`

- [x] Phase Ia: Hero bento (merged to main)
- [x] Phase Ib: Full bento migration (merged to main)
- [x] **Phase Ic: Responsive polish + tests (this PR)**

## Test plan

- [ ] 537/537 tests pass (10 new bento structural tests)
- [ ] Build: 102 pages
- [ ] Lint clean
- [ ] Mobile (375px): single column, stat pills scroll horizontally
- [ ] Tablet (768px): 2-col, featured cards 1 row height
- [ ] Desktop (1024px+): 4-col, featured cards 2×2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Polish the bento homepage’s responsive behavior and add structural regression tests for the generated bento grid HTML.

New Features:
- Enable horizontally scrollable stat pills layout on small mobile viewports.

Tests:
- Add bento grid structural tests validating hero, stats, featured cards, controls, personas, CTA, dual-view attributes, and removal of legacy home components.