### PR TITLE
fix(deps): pin typescript to ^5.9.3 (unblocks CI deploy)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Block typescript major bumps until @astrojs/check supports TS 6+
+      # (peer-dep ^5.0.0 → 6.0.3 caused npm ci ERESOLVE → CI failure for 9d)
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
 				"playwright": "1.59.1",
 				"satori": "0.26.0",
 				"text-readability": "1.1.1",
-				"typescript": "6.0.3",
+				"typescript": "^5.9.3",
 				"vitest": "4.1.5"
 			},
 			"engines": {
@@ -11035,10 +11035,10 @@
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-			"dev": true,
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
 		"playwright": "1.59.1",
 		"satori": "0.26.0",
 		"text-readability": "1.1.1",
-		"typescript": "6.0.3",
+		"typescript": "^5.9.3",
 		"vitest": "4.1.5"
 	},
 	"overrides": {


### PR DESCRIPTION
## Summary

CI has been failing on every push since 2026-04-26 with `npm error code ERESOLVE` because `typescript@6.0.3` was installed but `@astrojs/check@0.9.8` requires `typescript@^5.0.0`. Net effect: `gh-pages` last deployed 2026-02-28, so every commit since (including \`e22f719\` adding the Smart Contract / Security Audit \$2K tier to the consult page) is sitting on \`main\` but never made it live.

This pins typescript back to \`^5.9.3\` (the version the peer-dep wants) and adds a dependabot ignore for typescript major bumps so this won't recur next time TS rolls a major.

## What unblocks once this merges

- \`/portfolio/consult\` will finally show the Smart Contract / Security Audit (\$2K starting) tier with the Lido V3 audit link
- All cve-watch and Lido audit READMEs link to the consult page; they currently advertise a tier that isn't on the live site
- 7 cold-outreach emails sitting in Gmail Drafts reference \`4444j99.github.io/portfolio/consult\` — would have pointed to a stale page if sent before this lands

## Test plan

- [ ] CI passes on this PR (npm ci resolves cleanly, build succeeds, smoke test passes, gh-pages deploys)
- [ ] After merge: \`curl https://4444j99.github.io/portfolio/consult/ | grep "Smart Contract"\` returns the new tier
- [ ] After merge: subsequent dependabot runs do not propose typescript@6.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin TypeScript to a 5.x version compatible with Astro tooling to restore successful CI and deployments.

Build:
- Pin the TypeScript dev dependency to ^5.9.3 to align with @astrojs/check peer dependency and avoid npm ERESOLVE failures.

CI:
- Configure Dependabot to ignore TypeScript major version updates to prevent future CI breakage from incompatible TypeScript upgrades.