### PR TITLE
fix(frontend): OmegaGalaxy WebGL leak, reduced-motion, base-path hardcodes

### DIFF
--- a/src/components/galaxy/OmegaGalaxy.astro
+++ b/src/components/galaxy/OmegaGalaxy.astro
@@ -8,7 +8,7 @@ const projects = projectCatalog.map((p) => ({
 }));
 ---
 
-<div id="omega-galaxy-container" class="galaxy-container">
+<div id="omega-galaxy-container" class="galaxy-container" data-projects={JSON.stringify(projects)}>
   <canvas id="omega-galaxy-canvas"></canvas>
   <div id="galaxy-overlay" class="galaxy-overlay">
     <div id="repo-info" class="repo-info-card hidden">
@@ -33,11 +33,36 @@ const projects = projectCatalog.map((p) => ({
   import * as THREE from 'three';
   import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
-  const container = document.getElementById('omega-galaxy-container');
-  const canvas = document.getElementById('omega-galaxy-canvas') as HTMLCanvasElement;
-  
-  if (container && canvas) {
+  function createGlowTexture(color: string) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+
+    const gradient = ctx.createRadialGradient(32, 32, 0, 32, 32, 32);
+    gradient.addColorStop(0, color);
+    gradient.addColorStop(0.2, color);
+    gradient.addColorStop(0.5, 'rgba(0,0,0,0)');
+
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, 64, 64);
+
+    return new THREE.CanvasTexture(canvas);
+  }
+
+  let teardown: (() => void) | null = null;
+
+  function initGalaxy() {
+    if (teardown) return;
+    const container = document.getElementById('omega-galaxy-container');
+    const canvas = document.getElementById('omega-galaxy-canvas') as HTMLCanvasElement;
+    if (!container || !canvas) return;
+
     const projects = JSON.parse(container.dataset.projects || '[]');
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const controller = new AbortController();
+    let rafId = 0;
 
     // Initialize Scene
     const scene = new THREE.Scene();
@@ -66,7 +91,7 @@ const projects = projectCatalog.map((p) => ({
 
     // Position Logic: Distribute organs in a spiral/spherical volume
     const organKeys = [...new Set(projects.map((p: any) => p.organ))];
-    
+
     projects.forEach((project: any) => {
       const organIndex = organKeys.indexOf(project.organ);
       const organAngle = (organIndex / organKeys.length) * Math.PI * 2;
@@ -116,25 +141,6 @@ const projects = projectCatalog.map((p) => ({
     const bgStars = new THREE.Points(bgStarsGeometry, bgStarsMaterial);
     scene.add(bgStars);
 
-    function createGlowTexture(color: string) {
-      const canvas = document.createElement('canvas');
-      canvas.width = 64;
-      canvas.height = 64;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return null;
-      
-      const gradient = ctx.createRadialGradient(32, 32, 0, 32, 32, 32);
-      gradient.addColorStop(0, color);
-      gradient.addColorStop(0.2, color);
-      gradient.addColorStop(0.5, 'rgba(0,0,0,0)');
-      
-      ctx.fillStyle = gradient;
-      ctx.fillRect(0, 0, 64, 64);
-      
-      const texture = new THREE.CanvasTexture(canvas);
-      return texture;
-    }
-
     // Interactivity
     const infoCard = document.getElementById('repo-info');
     const repoTitle = document.getElementById('repo-title');
@@ -174,7 +180,7 @@ const projects = projectCatalog.map((p) => ({
       repoOrgan.textContent = project.organ;
       repoOrgan.style.backgroundColor = project.color;
       repoSummary.textContent = project.summary;
-      repoLink.href = `/portfolio/projects/${project.slug}`;
+      repoLink.href = `${import.meta.env.BASE_URL}projects/${project.slug}`;
       
       repoTags.innerHTML = '';
       project.tags.forEach((tag: string) => {
@@ -187,33 +193,60 @@ const projects = projectCatalog.map((p) => ({
       infoCard.classList.remove('hidden');
     }
 
-    canvas.addEventListener('pointerdown', onPointerDown);
+    canvas.addEventListener('pointerdown', onPointerDown, { signal: controller.signal });
 
     document.getElementById('reset-view')?.addEventListener('click', () => {
       camera.position.set(0, 0, 400);
       controls.target.set(0, 0, 0);
       infoCard?.classList.add('hidden');
-    });
+    }, { signal: controller.signal });
 
     window.addEventListener('resize', () => {
       if (!container) return;
       camera.aspect = container.clientWidth / container.clientHeight;
       camera.updateProjectionMatrix();
       renderer.setSize(container.clientWidth, container.clientHeight);
-    });
+    }, { signal: controller.signal });
 
     function animate() {
-      requestAnimationFrame(animate);
+      rafId = requestAnimationFrame(animate);
       controls.update();
-      
-      // Gentle rotation of the whole galaxy
-      scene.rotation.y += 0.0005;
-      
+      // Auto-rotation is autonomous motion; suppress it under reduced-motion.
+      if (!prefersReducedMotion) {
+        scene.rotation.y += 0.0005;
+      }
       renderer.render(scene, camera);
     }
 
     animate();
+
+    teardown = () => {
+      controller.abort();
+      cancelAnimationFrame(rafId);
+      controls.dispose();
+      scene.traverse((obj) => {
+        const mesh = obj as THREE.Mesh;
+        if (mesh.geometry) mesh.geometry.dispose();
+        const material = mesh.material as THREE.Material | THREE.Material[] | undefined;
+        if (material) {
+          const mats = Array.isArray(material) ? material : [material];
+          for (const m of mats) {
+            const tex = (m as THREE.MeshBasicMaterial).map;
+            if (tex) tex.dispose();
+            m.dispose();
+          }
+        }
+      });
+      renderer.dispose();
+      renderer.forceContextLoss();
+      teardown = null;
+    };
   }
+
+  document.addEventListener('astro:page-load', initGalaxy);
+  document.addEventListener('astro:before-swap', () => {
+    if (teardown) teardown();
+  });
 </script>
 
 <style>
@@ -362,7 +395,3 @@ const projects = projectCatalog.map((p) => ({
   }
 </style>
 
-<script is:inline define:vars={{ projects }}>
-  // Inject data into container for client script
-  document.getElementById('omega-galaxy-container').dataset.projects = JSON.stringify(projects);
-</script>

--- a/src/components/scripts/ClientBootstrap.astro
+++ b/src/components/scripts/ClientBootstrap.astro
@@ -20,7 +20,7 @@
   if (!bootstrapState.listenersAttached) {
     // Service worker registration — runs once on initial load
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/portfolio/sw.js').catch(() => {});
+      navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(() => {});
     }
 
     // Focus management for View Transitions — move focus to main content

--- a/src/components/sketches/sketch-loader.ts
+++ b/src/components/sketches/sketch-loader.ts
@@ -57,10 +57,23 @@ const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 let prefersReducedMotion = motionQuery.matches;
 motionQuery.addEventListener('change', (e) => {
 	prefersReducedMotion = e.matches;
+	// Re-apply to already-running instances — the persistent #bg-canvas survives
+	// navigations and would otherwise keep animating after reduced-motion is enabled.
+	for (const inst of instances.values()) {
+		if (!inst.draw) continue;
+		if (prefersReducedMotion) {
+			inst.noLoop();
+		} else {
+			inst.loop();
+		}
+	}
 });
 
 // Defer background sketch boot on the heaviest interactive routes.
-const BACKGROUND_DEFER_ROUTES = new Set(['/portfolio/architecture', '/portfolio/gallery']);
+const BACKGROUND_DEFER_ROUTES = new Set([
+	`${import.meta.env.BASE_URL}architecture`,
+	`${import.meta.env.BASE_URL}gallery`,
+]);
 
 // Track p5 instances for teardown (Map replaces former Set for VT readiness)
 const instances = new Map<HTMLElement, p5>();


### PR DESCRIPTION
Addresses high-severity frontend findings from the issue-discovery review (live on `main`).

## Changes
- **OmegaGalaxy (critical)** — was a module script that ran once, never re-initialized across view transitions (blank canvas on SPA nav), and never tore down (leaked the WebGL context, the `requestAnimationFrame` loop, and `resize`/`pointerdown` listeners on every navigation — browsers cap ~16 WebGL contexts). Now: init on `astro:page-load`; full teardown on `astro:before-swap` (`controller.abort()`, `cancelAnimationFrame`, dispose controls/geometries/materials/textures, `renderer.dispose()` + `forceContextLoss()`). Project data is server-rendered onto the container (drops the inline data script that wouldn't re-run on swap).
- **Reduced motion** — OmegaGalaxy suppresses its autonomous rotation under `prefers-reduced-motion`; and `sketch-loader`'s motion-query `change` handler now applies `noLoop()`/`loop()` to already-running instances, so the persistent `#bg-canvas` actually stops when reduced-motion is toggled mid-session (previously it only updated a flag).
- **Base-path hardcodes** — OmegaGalaxy repo link, `sketch-loader` defer-routes, and ClientBootstrap's `sw.js` registration now derive from `import.meta.env.BASE_URL` instead of literal `/portfolio/`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck:strict` — 0 hints (W12)
- [x] `npm run build` — 102 pages; omega page carries server-rendered `data-projects`
- [ ] Note: full "no leak across N navigations" + reduced-motion toggle are browser-runtime behaviors; verified by structure + the established AbortController/lifecycle pattern, not a live browser session.

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Fix OmegaGalaxy WebGL initialization and teardown for SPA view transitions, honor reduced-motion preferences in canvas animations, and remove hardcoded base paths for frontend routes and service worker registration.

Bug Fixes:
- Ensure OmegaGalaxy re-initializes on Astro page load and fully tears down before view swaps to prevent blank canvases and WebGL context leaks.
- Apply prefers-reduced-motion changes to running sketch instances so background animations correctly pause or resume when the setting toggles.

Enhancements:
- Server-render OmegaGalaxy project data on the container instead of using an inline data script for client initialization.
- Derive OmegaGalaxy project links, sketch-loader defer routes, and service worker registration URLs from import.meta.env.BASE_URL instead of hardcoded paths.