### PR TITLE
fix(ci): repair deploy rollback, workflow-name drift, governance docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,9 @@
 * @4444j99
 
 # Quality and security governance contracts
-.github/workflows/quality.yml @4444j99
-.github/workflows/security-drift.yml @4444j99
+.github/workflows/ci.yml @4444j99
+.github/workflows/monitor.yml @4444j99
+.github/workflows/refresh-data.yml @4444j99
 .github/pull_request_template.md @4444j99
 .quality/security-policy.json @4444j99
 .quality/ratchet-policy.json @4444j99

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,12 @@ jobs:
         id: deployment
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: actions/deploy-pages@v4
-      - name: Rollback on smoke failure
-        if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        run: |
-          echo "Smoke test failed — rolling back gh-pages"
-          git fetch origin gh-pages --depth=2
-          git push --force-with-lease origin HEAD~1:gh-pages
       - name: Smoke test
+        id: smoke
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         run: node scripts/post-deploy-smoke.mjs
+      - name: Flag failed deploy
+        if: always() && steps.smoke.outcome == 'failure'
+        run: |
+          echo "::error::Post-deploy smoke test failed — the live site may be serving a bad build. GitHub Pages artifact deploys cannot be auto-rolled-back via git; re-run a deploy from a known-good commit."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ We enforce a rigorous **Quality Ratchet** system via custom automation.
 Lighthouse CI enforcement: Perf ≥ 90, A11y ≥ 91, BP ≥ 93, SEO ≥ 92.
 
 ### Ratchet Schedules
-Coverage ratchet policy: W2 `12/8/8/12`, W4 `18/12/12/18`, W6 `25/18/18/25`, W8 `35/25/25/35`, W10 `45/32/32/45` (Statements/Branches/Functions/Lines).
+Coverage ratchet policy: W2 `12/8/8/12`, W4 `18/12/12/18`, W6 `25/18/18/25`, W8 `35/25/25/35`, W10 `45/32/32/45`, W12 `55/40/40/55` (Statements/Branches/Functions/Lines). Active phase: W12.
 
-Typecheck hint budget policy: W2 `<=20`, W4 `<=8`, W6 `=0`, W8 `=0`, W10 `=0`.
+Typecheck hint budget policy: W2 `<=20`, W4 `<=8`, W6 `=0`, W8 `=0`, W10 `=0`, W12 `=0`.
 
 Runtime a11y coverage ratchet: 100% enforcement (reached).
 

--- a/scripts/advance-ratchet-phase.mjs
+++ b/scripts/advance-ratchet-phase.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Advance or sync the quality ratchet default phase across policy, workflow, and CI.
- * Updates: ratchet-policy.json defaultPhase, quality.yml QUALITY_PHASE, README.md thresholds.
+ * Updates: ratchet-policy.json defaultPhase, ci.yml QUALITY_PHASE, README.md thresholds.
  *
  * Usage:
  *   node scripts/advance-ratchet-phase.mjs --phase W10 --dry-run   # preview
@@ -15,7 +15,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const POLICY_PATH = path.join(ROOT, '.quality/ratchet-policy.json');
-const WORKFLOW_PATH = path.join(ROOT, '.github/workflows/quality.yml');
+const WORKFLOW_PATH = path.join(ROOT, '.github/workflows/ci.yml');
 const README_PATH = path.join(ROOT, 'README.md');
 
 function parseArgs() {
@@ -84,7 +84,7 @@ function main() {
 		console.log(`  ratchet-policy.json: defaultPhase ${currentPhase} → ${phase}`);
 	}
 	if (workflowNeedsUpdate) {
-		console.log(`  quality.yml: QUALITY_PHASE → ${phase}`);
+		console.log(`  ci.yml: QUALITY_PHASE → ${phase}`);
 	}
 
 	// Generate README updates
@@ -131,7 +131,7 @@ function main() {
 	if (workflowNeedsUpdate) {
 		const updated = workflow.replace(/QUALITY_PHASE:\s*\w+/g, `QUALITY_PHASE: ${phase}`);
 		fs.writeFileSync(WORKFLOW_PATH, updated);
-		console.log('  ✓ Updated quality.yml');
+		console.log('  ✓ Updated ci.yml');
 	}
 
 	if (readmeChanged) {


### PR DESCRIPTION
Addresses CI/governance findings from the issue-discovery review.

## Changes
- **ci.yml deploy rollback (high)** — the "Rollback on smoke failure" step was ordered *before* the smoke test, so it could never fire on a smoke failure (only on earlier-step failures), and it force-pushed `HEAD~1` to `gh-pages` — invalid for artifact-based Pages deploys and capable of corrupting the branch. Reordered to **Deploy → Smoke test**, and replaced the broken git-push with a clear error annotation gated on the smoke step's `outcome` (artifact Pages can't be auto-rolled-back via git; a failed smoke now fails the run loudly with guidance).
- **`advance-ratchet-phase.mjs` (high)** — pointed `WORKFLOW_PATH` (and log/comment strings) at the real `ci.yml`; it referenced the nonexistent `quality.yml`, so the tool crashed with ENOENT on every run.
- **CODEOWNERS** — replaced nonexistent `quality.yml` / `security-drift.yml` entries with the real `ci.yml` / `monitor.yml` / `refresh-data.yml` so the actual workflows have an explicit owner.
- **README** — documented the active **W12** ratchet phase (coverage `55/40/40/55`, hints `=0`) that CI already enforces; appended after W10 so the governance-test regex (W2–W10) is unaffected.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck:strict` — 0 hints (W12)
- [x] `quality-governance.test.ts` — 5/5 (confirms the README W12 append doesn't break the parser)
- [x] `ci.yml` parses as valid YAML

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Align CI workflows, governance tooling, and documentation with the current quality ratchet configuration and improve deploy failure signaling.

Bug Fixes:
- Ensure the post-deploy smoke test runs after the deploy step and replace the invalid gh-pages rollback with a clear failure signal when smoke tests fail.
- Point the ratchet advancement script to the actual CI workflow file so it can update QUALITY_PHASE without crashing.

Enhancements:
- Document the W12 ratchet phase and thresholds in the README, including the active phase and updated typecheck hint budget policy.
- Update CODEOWNERS to reference the current CI- and monitoring-related workflows so ownership matches the actual files.