### PR TITLE
fix(types): make SystemMetrics match the current generate-data schema

### DIFF
--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -32,15 +32,21 @@ export interface PraxisTarget {
 
 export interface SystemMetrics {
 	generated: string;
-	sprint: string;
-	system: { name: string; launch_date: string; project_status: string };
+	// Newer generate-data schema (schema_version >= current) splits values into
+	// computed/manual blocks. Older flat fields below are optional because the
+	// current generator no longer emits them; dashboard consumers guard for absence.
+	schema_version?: number;
+	computed?: Record<string, unknown>;
+	manual?: Record<string, unknown>;
+	sprint?: string;
+	system?: { name: string; launch_date: string; project_status: string };
 	registry: {
 		total_repos: number;
 		total_organs: number;
 		operational_organs: number;
 		implementation_status: Record<string, number>;
-		tier_distribution: Record<string, number>;
-		promotion_status: Record<string, number>;
+		tier_distribution?: Record<string, number>;
+		promotion_status?: Record<string, number>;
 		ci_coverage: number;
 		dependency_edges: number;
 		organs: Record<string, Organ>;
@@ -55,7 +61,7 @@ export interface SystemMetrics {
 		classifications: Record<string, number>;
 		repos: FlagshipRepo[];
 	};
-	sprint_history: Sprint[];
+	sprint_history?: Sprint[];
 	praxis_targets?: Record<string, PraxisTarget>;
 	essays: { total: number };
 }


### PR DESCRIPTION
Addresses the `SystemMetrics` type-drift finding.

## Problem
The interface declared `sprint`, `system`, `sprint_history`, and `registry.tier_distribution`/`promotion_status` as **required**, but the current generated `system-metrics.json` (which uses a newer `schema_version` + `computed`/`manual` structure) emits **none** of them. `dashboard.astro` papered over this with `as unknown as SystemMetrics` and rendered those sections empty.

## Change
- Marked the absent flat fields **optional** and acknowledged the real `schema_version`/`computed`/`manual` blocks, so the type reflects the actual data.
- **No runtime/render change**: consumers already guard with `?.`/`|| []` and the data was already absent. Pure type-honesty.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck:strict` — 0 hints (all `SystemMetrics` consumers still typecheck with the now-optional fields)

> Separate product decision (not in this PR): the dashboard's `SprintTimeline` / `FlagshipVivification` / `PraxisTargets` sections have **no data source** in the current generator and always render empty — they should either be removed or the `generate-data` pipeline extended to populate them.

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Align SystemMetrics TypeScript interface with the current generate-data schema while remaining backward-compatible with older flat fields.

Bug Fixes:
- Allow SystemMetrics to correctly type newer schema_version-based system-metrics.json payloads without requiring absent fields.

Enhancements:
- Make legacy SystemMetrics fields optional and add schema_version/computed/manual properties to reflect actual generator output.