### PR TITLE
fix(pages): derive logos/pathos/press internal links from base

### DIFF
--- a/src/pages/logos/[slug].astro
+++ b/src/pages/logos/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
+import { base } from '../../utils/paths';
 
 export async function getStaticPaths() {
 	const logos = await getCollection('logos');
@@ -22,7 +23,7 @@ const { Content } = await render(entry);
   <article class="essay-article">
     <div class="container essay-container">
       <header class="essay-header">
-        <a href="/portfolio/logos/" class="back-link">← Back to Logos</a>
+        <a href={`${base}logos/`} class="back-link">← Back to Logos</a>
         <h1 class="essay-title">{entry.data.title}</h1>
         <div class="essay-meta">
           <time datetime={entry.data.pubDate.toISOString()}>

--- a/src/pages/logos/index.astro
+++ b/src/pages/logos/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
+import { base } from '../../utils/paths';
 
 const allLogos = await getCollection('logos');
 const sortedLogos = allLogos.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
@@ -20,7 +21,7 @@ const sortedLogos = allLogos.sort((a, b) => b.data.pubDate.valueOf() - a.data.pu
       <div class="essay-list">
         {sortedLogos.map(post => (
           <article class="essay-card">
-            <a href={`/portfolio/logos/${post.id}/`} class="essay-card__link">
+            <a href={`${base}logos/${post.id}/`} class="essay-card__link">
               <h2 class="essay-card__title">{post.data.title}</h2>
               <time class="essay-card__date" datetime={post.data.pubDate.toISOString()}>
                 {post.data.pubDate.toLocaleDateString('en-US', {

--- a/src/pages/pathos/[slug].astro
+++ b/src/pages/pathos/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
+import { base } from '../../utils/paths';
 
 export async function getStaticPaths() {
 	const pathos = await getCollection('pathos');
@@ -21,7 +22,7 @@ const { Content } = await render(entry);
   <article class="pathos-article">
     <div class="container pathos-container">
       <header class="pathos-header">
-        <a href="/portfolio/pathos/" class="back-link">&larr; Back to Pathos</a>
+        <a href={`${base}pathos/`} class="back-link">&larr; Back to Pathos</a>
         <h1 class="pathos-title">{entry.data.title}</h1>
         <div class="pathos-meta">
           <time datetime={entry.data.date.toISOString()}>

--- a/src/pages/pathos/index.astro
+++ b/src/pages/pathos/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
+import { base } from '../../utils/paths';
 
 const allPathos = await getCollection('pathos');
 const sorted = allPathos.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
@@ -25,7 +26,7 @@ const sorted = allPathos.sort((a, b) => b.data.date.valueOf() - a.data.date.valu
       <div class="pathos-list">
         {sorted.map(post => (
           <article class="pathos-entry">
-            <a href={`/portfolio/pathos/${post.id}/`} class="pathos-entry__link">
+            <a href={`${base}pathos/${post.id}/`} class="pathos-entry__link">
               <time class="pathos-entry__date" datetime={post.data.date.toISOString()}>
                 {post.data.date.toLocaleDateString('en-US', {
                   year: 'numeric',

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { base } from '../utils/paths';
 
 const mentions = [
 	{
@@ -52,7 +53,7 @@ const mentions = [
           </div>
           <div class="card">
             <h3>Operative Handbook</h3>
-            <p>Explore the full eight-organ architecture in the <a href="/portfolio/directory/">system directory</a> and review live quality metrics on the <a href="/portfolio/dashboard/">dashboard</a>.</p>
+            <p>Explore the full eight-organ architecture in the <a href={`${base}directory/`}>system directory</a> and review live quality metrics on the <a href={`${base}dashboard/`}>dashboard</a>.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Continuation of the base-path-hardcode cleanup (the documented "all internal URLs via `base`" invariant).

The logos and pathos index/detail pages and the press page hardcoded `/portfolio/` in internal links rather than importing `base`. Added `import { base }` and switched the 6 links to `${base}…`:
- `logos/[slug].astro` (back link), `logos/index.astro` (essay card link)
- `pathos/[slug].astro` (back link), `pathos/index.astro` (entry link)
- `press.astro` (directory + dashboard links)

External `github.com` URLs and the `about.astro` canonical microformat URL are intentionally absolute and left unchanged.

## Test plan
- [x] `npm run lint` / `typecheck:strict` — clean / 0 hints
- [x] `npm run build` — built HTML resolves to `/portfolio/logos/`, `/portfolio/pathos/…` (unchanged output, now base-derived)

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Route internal links for logos, pathos, and press pages through the shared base path utility instead of hardcoding portfolio URLs.

Enhancements:
- Use the shared base path helper for logos index/detail links and back navigation.
- Use the shared base path helper for pathos index/detail links and back navigation.
- Use the shared base path helper for press page links to the system directory and dashboard.