### PR TITLE
fix(quality-ratchet-kit): missing-metric failures, robust parseOption, strict preflight

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"quality:parallel:pre": "run-p lint typecheck:strict test:security:prod test:security check:freshness",
 		"quality:parallel:post": "run-p test validate test:a11y",
 		"quality:fast": "npm run quality:parallel:pre && npm run build && npm run quality:parallel:post",
-		"preflight": "npm run lint && npm run typecheck && npm run build && npm run validate && npm run sync:a11y-routes && npm run check:runtime-route-manifest && npm run test",
+		"preflight": "npm run lint && npm run typecheck:strict && npm run build && npm run validate && npm run sync:a11y-routes && npm run check:runtime-route-manifest && npm run test",
 		"test:ci": "npm run quality:local"
 	},
 	"dependencies": {

--- a/packages/quality-ratchet-kit/cli/check-quality-deltas.mjs
+++ b/packages/quality-ratchet-kit/cli/check-quality-deltas.mjs
@@ -10,7 +10,7 @@ const OUTPUT_PATH = resolve('.quality/delta-summary.json');
 
 function parseOption(argv, name) {
 	const eqArg = argv.find((entry) => entry.startsWith(`--${name}=`));
-	if (eqArg) return eqArg.split('=')[1] ?? null;
+	if (eqArg) return eqArg.slice(eqArg.indexOf('=') + 1);
 	const index = argv.indexOf(`--${name}`);
 	if (index >= 0) return argv[index + 1] ?? null;
 	return null;

--- a/packages/quality-ratchet-kit/cli/cli-utils.mjs
+++ b/packages/quality-ratchet-kit/cli/cli-utils.mjs
@@ -14,7 +14,7 @@ const args = process.argv.slice(2);
  */
 export function parseOption(name, fallback = null) {
 	const eq = args.find((entry) => entry.startsWith(`--${name}=`));
-	if (eq) return eq.split('=')[1] ?? fallback;
+	if (eq) return eq.slice(eq.indexOf('=') + 1);
 	const index = args.indexOf(`--${name}`);
 	if (index >= 0) return args[index + 1] ?? fallback;
 	return fallback;

--- a/packages/quality-ratchet-kit/src/threshold-checker.mjs
+++ b/packages/quality-ratchet-kit/src/threshold-checker.mjs
@@ -8,7 +8,10 @@ export function checkThresholds(actual, thresholds) {
 	const failures = [];
 	for (const [metric, threshold] of Object.entries(thresholds)) {
 		const value = actual[metric];
-		if (typeof value === 'number' && value < threshold) {
+		if (typeof value !== 'number' || Number.isNaN(value)) {
+			// A required metric that was never reported is a failure, not a skip.
+			failures.push({ metric, actual: value ?? null, threshold });
+		} else if (value < threshold) {
 			failures.push({ metric, actual: value, threshold });
 		}
 	}

--- a/packages/quality-ratchet-kit/test/ratchet-kit.test.mjs
+++ b/packages/quality-ratchet-kit/test/ratchet-kit.test.mjs
@@ -93,4 +93,14 @@ describe('threshold-checker', () => {
 		assert.equal(result.pass, false);
 		assert.equal(result.failures.length, 4);
 	});
+
+	it('fails when a required metric is missing', () => {
+		const result = checkThresholds(
+			{ statements: 30, branches: 20, lines: 30 },
+			{ statements: 25, branches: 18, functions: 18, lines: 25 },
+		);
+		assert.equal(result.pass, false);
+		assert.equal(result.failures.length, 1);
+		assert.equal(result.failures[0].metric, 'functions');
+	});
 });


### PR DESCRIPTION
Addresses medium-severity robustness findings.

- **`threshold-checker`** — a required metric that was never reported was silently skipped (neither pass nor fail), so a coverage run that failed to emit e.g. `branches` would still report `pass: true`. Now missing/non-numeric metrics are failures. Added a unit test for the missing-metric case.
- **`parseOption`** (duplicated in `cli-utils.mjs` + `check-quality-deltas.mjs`) — `split('=')[1]` truncated any option value containing `=` at the first `=`. Switched to `slice(indexOf('=') + 1)`.
- **`preflight`** — ran `typecheck` instead of `typecheck:strict`, so the local pre-push gate skipped the hint-budget ratchet CI enforces. Now uses `typecheck:strict`.

## Test plan
- [x] `npm run test:quality-ratchet-kit` — 12/12 (incl. new missing-metric test)
- [x] `npm run lint` / `typecheck:strict` — clean / 0 hints

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Tighten robustness of the quality-ratchet kit by treating missing coverage metrics as failures, handling CLI options with `=` in their values, and aligning the local preflight script with strict type checking enforced in CI.

Bug Fixes:
- Treat missing or non-numeric required coverage metrics as failures instead of silently skipping them.
- Ensure CLI option parsing preserves values that contain `=` characters.
- Use the strict type-checking script in the preflight command to match CI enforcement.

Tests:
- Add a unit test verifying that missing required coverage metrics cause threshold checks to fail.