### PR TITLE
feat(projects): add pages for a-mavs-olevm & collective-persona-operations

### DIFF
--- a/scripts/runtime-a11y-routes.json
+++ b/scripts/runtime-a11y-routes.json
@@ -170,6 +170,15 @@
       ]
     },
     {
+      "path": "/projects/a-mavs-olevm",
+      "checks": [
+        "nav-menu",
+        "dropdown-menu",
+        "search-dialog",
+        "theme-toggle"
+      ]
+    },
+    {
       "path": "/projects/aetheria-rpg",
       "checks": [
         "nav-menu",
@@ -207,6 +216,15 @@
     },
     {
       "path": "/projects/block-warfare",
+      "checks": [
+        "nav-menu",
+        "dropdown-menu",
+        "search-dialog",
+        "theme-toggle"
+      ]
+    },
+    {
+      "path": "/projects/collective-persona-operations",
       "checks": [
         "nav-menu",
         "dropdown-menu",

--- a/src/pages/projects/a-mavs-olevm.astro
+++ b/src/pages/projects/a-mavs-olevm.astro
@@ -1,0 +1,37 @@
+---
+import ProjectLayout from '../../layouts/ProjectLayout.astro';
+---
+
+<ProjectLayout
+  pageTitle="A-Mavs-Olevm — 4444j"
+  description="The 'Living Pantheon' — a flagship artistic ecosystem and website built framework-free with a performance-first discipline."
+  sketchId="kaleidoscope"
+  title="A-Mavs-Olevm"
+  tagline="The 'Living Pantheon' — a flagship artistic ecosystem and website"
+  tags={['Art', 'Vanilla JS', 'Performance']}
+>
+  <h2>Overview</h2>
+  <p>
+    A-Mavs-Olevm is the "Living Pantheon": a flagship artistic ecosystem and
+    website within Organ II (Poiesis), the creative-art organ of the system. It
+    treats the website itself as the artwork — an evolving, interactive surface
+    rather than a static portfolio of finished pieces.
+  </p>
+  <h2>Approach</h2>
+  <ul>
+    <li>
+      <strong>Framework-free</strong> — built with vanilla JavaScript, with no
+      framework runtime, so the implementation stays small and fully under
+      direct control.
+    </li>
+    <li>
+      <strong>Performance-first</strong> — fast load and responsive interaction
+      are treated as first-class design constraints, not afterthoughts.
+    </li>
+    <li>
+      <strong>Living ecosystem</strong> — the work is designed to grow and
+      recompose over time rather than ship as a fixed release.
+    </li>
+  </ul>
+  <p><em>An expanded case study for this project is in progress.</em></p>
+</ProjectLayout>

--- a/src/pages/projects/collective-persona-operations.astro
+++ b/src/pages/projects/collective-persona-operations.astro
@@ -1,0 +1,37 @@
+---
+import ProjectLayout from '../../layouts/ProjectLayout.astro';
+---
+
+<ProjectLayout
+  pageTitle="Collective Persona Operations — 4444j"
+  description="A framework for managing multi-agent identity state-shifts and role-playing within the organ system."
+  sketchId="lenses"
+  title="Collective Persona Operations"
+  tagline="Managing multi-agent identity state-shifts and role-playing"
+  tags={['Theory', 'AI', 'Identity']}
+>
+  <h2>Overview</h2>
+  <p>
+    Collective Persona Operations is a framework, within Organ I (Theoria), for
+    managing how multiple AI agents adopt, shift between, and coordinate
+    distinct personas. It treats identity as explicit, manipulable state rather
+    than an implicit property of a single prompt.
+  </p>
+  <h2>Focus</h2>
+  <ul>
+    <li>
+      <strong>Identity state-shifts</strong> — modeling the transitions an agent
+      makes when it moves between roles, so behavior stays coherent across
+      shifts.
+    </li>
+    <li>
+      <strong>Multi-agent role-playing</strong> — coordinating a set of personas
+      that interact as a collective rather than in isolation.
+    </li>
+    <li>
+      <strong>Theory-grounded</strong> — framed as a conceptual model first,
+      informing how persona behavior is structured across the system.
+    </li>
+  </ul>
+  <p><em>An expanded case study for this project is in progress.</em></p>
+</ProjectLayout>


### PR DESCRIPTION
Builds the two missing project pages so the OmegaGalaxy stops 404'ing (per your "build pages" decision).

## Context
`a-mavs-olevm` and `collective-persona-operations` exist in `project-catalog`, and `OmegaGalaxy` links every catalog entry to `projects/<slug>` — but these two had no page, so clicking their stars 404'd.

## Changes
- Added `src/pages/projects/a-mavs-olevm.astro` and `…/collective-persona-operations.astro` — honest, concise case studies built from the real catalog data (title / summary / organ / tags) via the shared `ProjectLayout`. **No fabricated metrics, citations, or architecture claims**; each notes an expanded writeup is pending.
- Synced `scripts/runtime-a11y-routes.json` (102 → 104 routes) per the page-addition invariant.

Left `project-index`/`organ-groups` untouched: file-based routing already resolves the pages, and adding them there would pull in the `index ≡ organ-groups` invariant + curated homepage entries (a separate task). The galaxy 404 is fixed regardless.

## Test plan
- [x] `npm run build` — 104 pages; both pages render
- [x] `npm run check:runtime-route-manifest` — passes (104)
- [x] `npm run lint` / `typecheck:strict` — clean / 0 hints
- [x] data + catalog-sync tests — 79/79

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Add missing project pages for existing catalog entries and update the runtime accessibility routes manifest accordingly.

New Features:
- Introduce dedicated project pages for A-Mavs-Olevm and Collective Persona Operations using the shared project layout.

Build:
- Update the runtime accessibility routes manifest to include the two new project pages.