### PR TITLE
feat: Stripe checkout + testimonials scaffolding (#16, #17)

### DIFF
--- a/src/data/testimonials.json
+++ b/src/data/testimonials.json
@@ -1,0 +1,3 @@
+{
+	"testimonials": []
+}

--- a/src/pages/testimonials.astro
+++ b/src/pages/testimonials.astro
@@ -1,9 +1,13 @@
 ---
 import StatGrid from '../components/StatGrid.astro';
 import omegaData from '../data/omega.json';
+import testimonialsData from '../data/testimonials.json';
 import vitals from '../data/vitals.json';
 import Layout from '../layouts/Layout.astro';
+import type { Testimonial } from '../types/data';
 import { base } from '../utils/paths';
+
+const testimonials: Testimonial[] = testimonialsData.testimonials;
 
 const soakDay = omegaData.soak.streak_days;
 const targetDay = omegaData.soak.target_days;
@@ -79,10 +83,37 @@ const feedbackCriteria = [
       </div>
 
       <h2 class="section__heading" data-reveal>Current Feedback Logs</h2>
-      <div class="empty-state">
-        <p>No external testimonials logged yet. System is currently in autonomous soak mode.</p>
-        <p class="small">Refer to <a href={`${base}omega/`}>Omega Criterion #7</a> for tracking status.</p>
-      </div>
+      {testimonials.length > 0 ? (
+        <div class="testimonial-grid">
+          {testimonials.map((t) => (
+            <figure class="testimonial-card" data-reveal>
+              <blockquote class="testimonial-card__quote">{t.quote}</blockquote>
+              <figcaption class="testimonial-card__meta">
+                <span class="testimonial-card__name">{t.name}</span>
+                {t.role && <span class="testimonial-card__role">{t.role}</span>}
+                {t.source &&
+                  (t.sourceUrl ? (
+                    <a
+                      class="testimonial-card__source"
+                      href={t.sourceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {t.source}
+                    </a>
+                  ) : (
+                    <span class="testimonial-card__source">{t.source}</span>
+                  ))}
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+      ) : (
+        <div class="empty-state">
+          <p>No external testimonials logged yet. System is currently in autonomous soak mode.</p>
+          <p class="small">Refer to <a href={`${base}omega/`}>Omega Criterion #7</a> for tracking status.</p>
+        </div>
+      )}
     </div>
   </section>
 </Layout>
@@ -191,5 +222,45 @@ const feedbackCriteria = [
   }
   .btn--secondary:hover {
     background: var(--bg-card);
+  }
+  .testimonial-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: var(--space-lg);
+    margin: var(--space-xl) 0;
+  }
+  .testimonial-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: var(--space-xl);
+    margin: 0;
+  }
+  .testimonial-card__quote {
+    margin: 0 0 var(--space-md);
+    border-left: 2px solid var(--accent);
+    padding-left: var(--space-md);
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+  .testimonial-card__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .testimonial-card__name {
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .testimonial-card__role {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+  .testimonial-card__source {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--accent);
+    text-decoration: none;
+    margin-top: var(--space-xs);
   }
 </style>

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -66,6 +66,15 @@ export interface SystemMetrics {
 	essays: { total: number };
 }
 
+export interface Testimonial {
+	name: string;
+	role?: string;
+	quote: string;
+	date?: string;
+	source?: string;
+	sourceUrl?: string;
+}
+
 export interface Essay {
 	path: string;
 	filename: string;

--- a/workers/consult-api/src/index.ts
+++ b/workers/consult-api/src/index.ts
@@ -4,6 +4,10 @@ interface Env {
 	ALLOWED_ORIGINS?: string;
 	LOG_HASH_SALT?: string;
 	KNOWLEDGE_API_URL?: string;
+	// Commerce (Stripe) — checkout is inert until both are set as secrets.
+	STRIPE_SECRET_KEY?: string;
+	STRIPE_PRICE_ID?: string;
+	SITE_URL?: string;
 }
 
 interface ConsultRequestBody {
@@ -276,6 +280,48 @@ ${contextSection}
 Be specific, practical, and implementation-oriented. When grounded context is available, reference specific repos and capabilities by name.`;
 }
 
+async function handleCheckout(request: Request, env: Env, corsHeaders: Headers): Promise<Response> {
+	if (!env.STRIPE_SECRET_KEY || !env.STRIPE_PRICE_ID) {
+		return jsonResponse(
+			{ ok: false, code: 'NOT_CONFIGURED', message: 'Checkout is not configured.' },
+			503,
+			corsHeaders,
+		);
+	}
+	const siteUrl = request.headers.get('Origin') || env.SITE_URL || 'https://4444j99.github.io';
+	try {
+		const params = new URLSearchParams();
+		params.set('mode', 'payment');
+		params.set('line_items[0][price]', env.STRIPE_PRICE_ID);
+		params.set('line_items[0][quantity]', '1');
+		params.set('success_url', `${siteUrl}/portfolio/consult/?checkout=success`);
+		params.set('cancel_url', `${siteUrl}/portfolio/consult/?checkout=cancel`);
+		const res = await fetch('https://api.stripe.com/v1/checkout/sessions', {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${env.STRIPE_SECRET_KEY}`,
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: params.toString(),
+		});
+		if (!res.ok) {
+			return jsonResponse(
+				{ ok: false, code: 'STRIPE_ERROR', message: 'Could not create checkout session.' },
+				502,
+				corsHeaders,
+			);
+		}
+		const session = (await res.json()) as { id?: string; url?: string };
+		return jsonResponse({ ok: true, id: session.id, url: session.url }, 200, corsHeaders);
+	} catch {
+		return jsonResponse(
+			{ ok: false, code: 'STRIPE_ERROR', message: 'Could not create checkout session.' },
+			502,
+			corsHeaders,
+		);
+	}
+}
+
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		const origin = request.headers.get('Origin');
@@ -288,6 +334,10 @@ export default {
 
 		if (request.method === 'GET' && url.pathname === '/health') {
 			return jsonResponse({ ok: true, service: 'consult-api' }, 200, corsHeaders);
+		}
+
+		if (request.method === 'POST' && url.pathname === '/api/checkout') {
+			return handleCheckout(request, env, corsHeaders);
 		}
 
 		if (request.method !== 'POST' || url.pathname !== '/api/consult') {


### PR DESCRIPTION
Builds the **codeable shells** for #16 and #17 (the human-gated parts stay with you).

## #17 — testimonials (data-driven)
`testimonials.astro` now renders its "Current Feedback Logs" from a new hand-editable `src/data/testimonials.json` (`{ "testimonials": [] }` → existing empty-state). Added a `Testimonial` type. When real validator feedback arrives, logging it is a data edit, not a layout change.

## #16 — Stripe checkout (inert until configured)
Added `POST /api/checkout` to the consult worker:
- Returns `503 NOT_CONFIGURED` unless **both** `STRIPE_SECRET_KEY` and `STRIPE_PRICE_ID` are set as secrets — so it's a no-op on the current deployment.
- When configured, creates a Stripe Checkout Session via the Stripe REST API (no SDK dependency) and returns the redirect URL. Added the env fields.

Still yours: provisioning Stripe + verifying a live transaction (#16), and recruiting validators (#17).

## Test plan
- [x] `npm run lint` / `typecheck:strict` — clean / 0 hints
- [x] `npm run build` — testimonials renders empty-state
- [x] worker `esbuild --bundle` + contract tests — clean / 6/6
- [ ] Stripe path not runtime-verified (no Cloudflare runtime; worker is deploy-on-demand). Validate with `wrangler dev` + a test key before relying on it.

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Wire up data-driven testimonials rendering and add a Stripe checkout endpoint for consult sessions, guarded by configuration.

New Features:
- Render testimonials on the testimonials page from a new JSON data source using a typed Testimonial model.
- Expose a POST /api/checkout endpoint in the consult worker that creates Stripe Checkout Sessions when Stripe is configured.

Enhancements:
- Style testimonials in a responsive card grid layout on the testimonials page.