### PR TITLE
fix(scripts): atomic JSON writes in sync + data-mutating scripts

### DIFF
--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -1,0 +1,20 @@
+import { renameSync, writeFileSync } from 'node:fs';
+
+/**
+ * Write JSON to disk atomically: serialize to a temp file in the same
+ * directory, then rename over the target. rename(2) is atomic on a single
+ * filesystem, so a crash or interruption mid-write leaves the original file
+ * intact rather than truncated/corrupted.
+ *
+ * @param {string} filePath - Destination path.
+ * @param {unknown} data - Value to JSON.stringify.
+ * @param {{ indent?: number | string, trailingNewline?: boolean }} [opts]
+ *   indent/trailingNewline preserve each caller's existing output format.
+ */
+export function writeJsonAtomic(filePath, data, opts = {}) {
+	const { indent = 2, trailingNewline = true } = opts;
+	const body = JSON.stringify(data, null, indent) + (trailingNewline ? '\n' : '');
+	const tmpPath = `${filePath}.tmp-${process.pid}`;
+	writeFileSync(tmpPath, body, 'utf8');
+	renameSync(tmpPath, filePath);
+}

--- a/scripts/scout-agent.mjs
+++ b/scripts/scout-agent.mjs
@@ -10,6 +10,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { writeJsonAtomic } from './lib/atomic-write.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CANDIDATES_PATH = path.join(__dirname, '../src/data/scout-candidates.json');
@@ -61,7 +62,7 @@ async function scout() {
 	}
 
 	candidates.last_scout = new Date().toISOString();
-	fs.writeFileSync(CANDIDATES_PATH, JSON.stringify(candidates, null, 2));
+	writeJsonAtomic(CANDIDATES_PATH, candidates, { trailingNewline: false });
 	console.log(`
 ✅ Scouting complete. ${candidates.candidates.filter((c) => c.status === 'triage').length} candidates in triage.`);
 }

--- a/scripts/strike-new.mjs
+++ b/scripts/strike-new.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { generateOGImage } from './generate-og-images.mjs';
+import { writeJsonAtomic } from './lib/atomic-write.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TARGETS_PATH = path.join(__dirname, '../src/data/targets.json');
@@ -113,7 +114,7 @@ async function createStrike() {
 
 	data.targets.unshift(newTarget);
 
-	fs.writeFileSync(TARGETS_PATH, JSON.stringify(data, null, 2) + '\n');
+	writeJsonAtomic(TARGETS_PATH, data);
 
 	// Generate bespoke OG image
 	console.log(`🎨 Generating bespoke social card for ${company}...`);

--- a/scripts/sync-a11y-routes.mjs
+++ b/scripts/sync-a11y-routes.mjs
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { writeJsonAtomic } from './lib/atomic-write.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -123,7 +124,7 @@ async function generateA11yRoutes() {
 		routes,
 	};
 
-	fs.writeFileSync(OUTPUT_PATH, JSON.stringify(manifest, null, 2) + '\n');
+	writeJsonAtomic(OUTPUT_PATH, manifest);
 	console.log(`✅ Successfully generated ${routes.length} routes for A11y runtime audit.`);
 }
 

--- a/scripts/sync-identity.mjs
+++ b/scripts/sync-identity.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { writeJsonAtomic } from './lib/atomic-write.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ABOUT_PATH = path.join(__dirname, '../src/data/about.json');
@@ -40,7 +41,7 @@ function syncIdentity() {
 	about.system_summary = summary;
 	about.generated = new Date().toISOString();
 
-	fs.writeFileSync(ABOUT_PATH, JSON.stringify(about, null, '\t'), 'utf8');
+	writeJsonAtomic(ABOUT_PATH, about, { indent: '\t', trailingNewline: false });
 	console.log(`🚀 Identity synchronized: ${totalRepos} repos, ${ciWorkflows} CI workflows.`);
 }
 

--- a/scripts/sync-omega.mjs
+++ b/scripts/sync-omega.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { writeJsonAtomic } from './lib/atomic-write.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OMEGA_PATH = path.join(__dirname, '../src/data/omega.json');
@@ -45,7 +46,7 @@ async function syncOmega() {
 
 	omega.generated = new Date().toISOString().split('T')[0];
 
-	fs.writeFileSync(OMEGA_PATH, JSON.stringify(omega, null, 2) + '\n');
+	writeJsonAtomic(OMEGA_PATH, omega);
 	console.log(
 		`✅ Omega Scorecard synchronized. Horizon 2 (Criterion 5) linked to ${targetCount} active strike targets.`,
 	);

--- a/scripts/sync-trust-metrics.mjs
+++ b/scripts/sync-trust-metrics.mjs
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { writeJsonAtomic } from './lib/atomic-write.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const QUALITY_DIR = path.join(__dirname, '../.quality');
@@ -89,7 +90,7 @@ async function syncVitals() {
 		console.warn('⚠️ Could not parse github-pages-telemetry.json');
 	}
 
-	fs.writeFileSync(TRUST_VITALS_PATH, JSON.stringify(trustVitals, null, 2));
+	writeJsonAtomic(TRUST_VITALS_PATH, trustVitals, { trailingNewline: false });
 	console.log(`✅ Trust Vitals synced to ${TRUST_VITALS_PATH}`);
 
 	// 4. Derive vitals.json from system-metrics.json
@@ -126,7 +127,7 @@ async function syncVitals() {
 			timestamp: metrics.generated,
 		};
 
-		fs.writeFileSync(VITALS_PATH, JSON.stringify(vitals, null, 2));
+		writeJsonAtomic(VITALS_PATH, vitals, { trailingNewline: false });
 		console.log(`✅ Derived Vitals synced to ${VITALS_PATH}`);
 
 		// 5. Update landing.json metrics from system-metrics.json
@@ -143,7 +144,7 @@ async function syncVitals() {
 				sprints_completed: metrics.sprints?.completed ?? 0,
 			};
 			landing.generated = metrics.generated;
-			fs.writeFileSync(LANDING_PATH, JSON.stringify(landing, null, 2));
+			writeJsonAtomic(LANDING_PATH, landing, { trailingNewline: false });
 			console.log(`✅ Landing Metrics synced to ${LANDING_PATH}`);
 		}
 	} catch (e) {

--- a/scripts/sync-workspace-health.mjs
+++ b/scripts/sync-workspace-health.mjs
@@ -12,8 +12,9 @@
  * Requires: GH_TOKEN or GITHUB_TOKEN environment variable for API access.
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { writeJsonAtomic } from './lib/atomic-write.mjs';
 
 const DEFAULT_OUTPUT = resolve('src/data/workspace-health.json');
 const args = process.argv.slice(2);
@@ -91,7 +92,7 @@ async function main() {
 	};
 
 	mkdirSync(dirname(outputPath), { recursive: true });
-	writeFileSync(outputPath, JSON.stringify(output, null, 2) + '\n');
+	writeJsonAtomic(outputPath, output);
 	console.log(`Wrote workspace health to ${outputPath}`);
 }
 


### PR DESCRIPTION
Addresses the non-atomic-write finding in the sync + data-mutating scripts.

Added `scripts/lib/atomic-write.mjs` — `writeJsonAtomic()` writes to a temp file in the same directory then `rename(2)`s over the target (atomic on one filesystem), so a crash or interrupt mid-write can no longer truncate the destination. Highest value for the **hand-edited** files (`targets.json`, `scout-candidates.json`) that have no regeneration safety net.

Applied to the in-place rewrites in: `sync-omega`, `sync-identity`, `sync-trust-metrics` (trust-vitals/vitals/landing), `sync-workspace-health`, `sync-a11y-routes`, `strike-new`, `scout-agent`.

**Format is byte-preserved** per call (indent + trailing-newline options replicate each prior `writeFileSync`), so generated files don't change shape.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck:strict` — 0 hints
- [x] `npm run sync:omega` runs and emits valid JSON; round-trip format check preserved for omega/about/trust-vitals (vitals/landing replicate the script's pre-existing no-trailing-newline output)

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Enhancements:
- Introduce a shared atomic JSON writer utility used across scripts to preserve existing file formatting while making writes crash-safe.