### PR TITLE
fix(components): AbortController lifecycle + focus traps for interactive controls

### DIFF
--- a/src/components/home/ControlsBentoCell.astro
+++ b/src/components/home/ControlsBentoCell.astro
@@ -74,7 +74,9 @@ import DepthControl from '../shibui/DepthControl.astro';
 </style>
 
 <script>
-function initBentoViewToggle() {
+let bentoController: AbortController | null = null;
+
+function initBentoViewToggle(signal: AbortSignal) {
 	const btns = document.querySelectorAll<HTMLButtonElement>('[data-bento-view]');
 	if (!btns.length) return;
 
@@ -115,9 +117,13 @@ function initBentoViewToggle() {
 				b.classList.toggle('view-toggle__btn--active', filterView === view);
 				b.setAttribute('aria-pressed', String(filterView === view));
 			});
-		});
+		}, { signal });
 	});
 }
 
-document.addEventListener('astro:page-load', initBentoViewToggle);
+document.addEventListener('astro:page-load', () => {
+	bentoController?.abort();
+	bentoController = new AbortController();
+	initBentoViewToggle(bentoController.signal);
+});
 </script>

--- a/src/components/resume/GovernancePreview.astro
+++ b/src/components/resume/GovernancePreview.astro
@@ -38,7 +38,9 @@ const { trace } = sample;
 </div>
 
 <script>
-  function setupGovPreview() {
+  let govController: AbortController | null = null;
+
+  function setupGovPreview(signal: AbortSignal) {
     const preview = document.getElementById('gov-preview');
     const closeBtn = document.getElementById('close-gov-preview') as HTMLButtonElement;
     const trigger = document.getElementById('view-trace-btn');
@@ -58,8 +60,8 @@ const { trace } = sample;
       (trigger as HTMLElement).focus();
     }
 
-    trigger.addEventListener('click', openPreview);
-    closeBtn.addEventListener('click', closePreview);
+    trigger.addEventListener('click', openPreview, { signal });
+    closeBtn.addEventListener('click', closePreview, { signal });
 
     // Trap focus and handle keyboard
     preview.addEventListener('keydown', (e) => {
@@ -69,14 +71,24 @@ const { trace } = sample;
         e.preventDefault();
         closeBtn.focus(); // Only one focusable element in this simple modal, so we loop back to it
       }
-    });
+    }, { signal });
 
     preview.addEventListener('click', (e) => {
       if (e.target === preview) closePreview();
-    });
+    }, { signal });
   }
 
-  document.addEventListener('astro:page-load', setupGovPreview);
+  document.addEventListener('astro:page-load', () => {
+    govController?.abort();
+    govController = new AbortController();
+    setupGovPreview(govController.signal);
+  });
+  document.addEventListener('astro:before-swap', () => {
+    govController?.abort();
+    govController = null;
+    // Reset the scroll-lock in case we navigate away while the modal is open.
+    document.body.style.overflow = '';
+  });
 </script>
 
 <style>

--- a/src/components/shibui/DepthControl.astro
+++ b/src/components/shibui/DepthControl.astro
@@ -30,7 +30,9 @@
 
   declare const plausible: ((event: string, opts?: { props?: Record<string, string> }) => void) | undefined;
 
-  function initDepthControl() {
+  let depthController: AbortController | null = null;
+
+  function initDepthControl(signal: AbortSignal) {
     const btn = document.querySelector<HTMLButtonElement>('[data-shibui-control]');
     if (!btn) return;
 
@@ -111,9 +113,13 @@
     // Initialize visual state from current attribute
     applyDepth(getCurrentDepth());
 
-    btn.addEventListener('click', () => {
-      applyDepth(nextDepth(getCurrentDepth()));
-    });
+    btn.addEventListener(
+      'click',
+      () => {
+        applyDepth(nextDepth(getCurrentDepth()));
+      },
+      { signal },
+    );
 
     btn.addEventListener('keydown', (e: KeyboardEvent) => {
       if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
@@ -123,7 +129,7 @@
         e.preventDefault();
         applyDepth(stepDepth(getCurrentDepth(), 'shallower'));
       }
-    });
+    }, { signal });
   }
 
   // Bridge button label map — contextual text driven by data-shibui-bridge-label attribute
@@ -147,7 +153,7 @@
   }
 
   // Local expand: clicking a bridge button toggles `data-shibui-expanded` on its sibling ShibuiContent
-  function initBridgeExpanders() {
+  function initBridgeExpanders(signal: AbortSignal) {
     document.querySelectorAll<HTMLButtonElement>('.shibui-bridge').forEach(btn => {
       // Set initial contextual text (replaces generic HTML fallback)
       btn.textContent = bridgeText(btn);
@@ -172,13 +178,15 @@
             plausible('Bridge Click', { props: { section: unitId, action: expanded ? 'collapse' : 'expand' } });
           }
         }
-      });
+      }, { signal });
     });
   }
 
   // Initialize on page load and view transitions
   document.addEventListener('astro:page-load', () => {
-    initDepthControl();
-    initBridgeExpanders();
+    depthController?.abort();
+    depthController = new AbortController();
+    initDepthControl(depthController.signal);
+    initBridgeExpanders(depthController.signal);
   });
 </script>

--- a/src/components/shibui/ShibuiOnboarding.astro
+++ b/src/components/shibui/ShibuiOnboarding.astro
@@ -56,6 +56,8 @@
 <script>
   declare const plausible: ((event: string, opts?: { props?: Record<string, string> }) => void) | undefined;
 
+  let onboardingController: AbortController | null = null;
+
   function initOnboarding() {
     const el = document.getElementById('shibui-onboarding');
     if (!el) return;
@@ -65,15 +67,27 @@
       return;
     }
 
+    // Avoid double-wiring if re-invoked on an already-initialized panel.
+    if (onboardingController) return;
+
     // Narrow to non-null for closures
     const panel = el;
     const cards = panel.querySelectorAll<HTMLButtonElement>('[data-depth]');
     const skipBtn = document.getElementById('shibui-onboarding-skip');
     const backdrop = panel.querySelector<HTMLElement>('.shibui-onboarding__backdrop');
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const focusables = [...cards, ...(skipBtn ? [skipBtn] : [])] as HTMLElement[];
+
+    const controller = new AbortController();
+    onboardingController = controller;
+    const { signal } = controller;
 
     function dismiss() {
+      controller.abort();
+      onboardingController = null;
       panel.classList.add('shibui-onboarding--hiding');
       setTimeout(() => panel.remove(), 250);
+      previouslyFocused?.focus?.();
     }
 
     function chooseDepth(depth: string) {
@@ -87,26 +101,60 @@
     }
 
     cards.forEach((card) => {
-      card.addEventListener('click', () => {
-        const depth = card.dataset.depth;
-        if (depth) chooseDepth(depth);
-      });
+      card.addEventListener(
+        'click',
+        () => {
+          const depth = card.dataset.depth;
+          if (depth) chooseDepth(depth);
+        },
+        { signal },
+      );
     });
 
-    skipBtn?.addEventListener('click', dismiss);
-    backdrop?.addEventListener('click', dismiss);
+    skipBtn?.addEventListener('click', dismiss, { signal });
+    backdrop?.addEventListener('click', dismiss, { signal });
 
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') dismiss();
-    });
+    document.addEventListener(
+      'keydown',
+      (e) => {
+        if (e.key === 'Escape') {
+          dismiss();
+          return;
+        }
+        // Trap focus inside the modal dialog while it is open.
+        if (e.key === 'Tab' && focusables.length > 0) {
+          const first = focusables[0];
+          const last = focusables[focusables.length - 1];
+          const active = document.activeElement;
+          if (!panel.contains(active)) {
+            e.preventDefault();
+            first.focus();
+          } else if (e.shiftKey && active === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && active === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      },
+      { signal },
+    );
 
     requestAnimationFrame(() => {
       panel.classList.add('shibui-onboarding--visible');
+      focusables[0]?.focus();
     });
+  }
+
+  function teardownOnboarding() {
+    onboardingController?.abort();
+    onboardingController = null;
   }
 
   initOnboarding();
   document.addEventListener('astro:after-swap', initOnboarding);
+  document.addEventListener('astro:before-swap', teardownOnboarding);
 </script>
 
 <style is:global>


### PR DESCRIPTION
Addresses the lifecycle/focus-trap findings in four interactive controls.

All four re-bound listeners on every `astro:page-load`/`after-swap` with **no AbortController**, accumulating handlers on persistent elements (notably the header's DepthControl button) and leaking a `document` keydown in the onboarding modal.

- **DepthControl, ControlsBentoCell, GovernancePreview** — listeners now scoped to an AbortController that is aborted + recreated on each `page-load` (matches the project's enforced pattern).
- **ShibuiOnboarding** — controller scoped to the panel; aborted on dismiss and on `before-swap`; added a guard against double-wiring.
- **Focus traps** — ShibuiOnboarding now traps Tab + Escape with initial focus and focus restore on close; GovernancePreview's trap retained and scoped.
- **Scroll-lock leak** — GovernancePreview resets `document.body.style.overflow` on `before-swap`, so navigating away with the modal open can't leave the next page scroll-locked.

## Test plan
- [x] `npm run lint` / `typecheck:strict` — clean / 0 hints
- [x] `npm run build`
- [x] component tests — 72/72 (incl. `listener-lifecycle.test.ts`)
- [ ] Focus-trap behavior implemented to the standard pattern but not browser-verified here.

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Ensure interactive controls clean up event listeners correctly across Astro page transitions and improve modal focus handling.

Bug Fixes:
- Prevent duplicate event listeners and leaks in ShibuiOnboarding, DepthControl, ControlsBentoCell, and GovernancePreview by scoping handlers to AbortControllers tied to page lifecycle.
- Fix ShibuiOnboarding modal to restore focus on close and avoid double-initialization when reinvoked.
- Ensure GovernancePreview clears body scroll-lock and aborts its listeners when navigating away or before Astro swaps.

Enhancements:
- Add proper focus trapping, initial focus, and Escape handling to the ShibuiOnboarding modal consistent with the project's modal behavior patterns.