### PR TITLE
fix(generate-data): make compute_vitals snapshot enrichment reachable

### DIFF
--- a/scripts/generate-system-data.py
+++ b/scripts/generate-system-data.py
@@ -103,7 +103,7 @@ def compute_vitals(canonical: dict, snapshot: dict | None = None) -> dict:
     code_files = canonical.get("code_files", total_repos * 20)
     test_files = canonical.get("test_files", auto_tests // 5)
 
-    return {
+    vitals = {
         "repos": {
             "total": total_repos,
             "active": c.get("active_repos", 0),


### PR DESCRIPTION
Fixes the dead-code bug in the local `generate-system-data.py` (the data-pipeline "extend" item).

`compute_vitals` returned its base dict via `return { ... }`, so the snapshot-enrichment block after it (organism / omega / promotion_pipeline) was **unreachable dead code** that also referenced an undefined `vitals`. Changed the early `return {` to `vitals = {` so the enrichment runs and the existing trailing `return vitals` returns the enriched object.

## Test plan
- [x] `python3 -m py_compile` — syntax OK
- [x] functional test: with a snapshot, `compute_vitals` now includes `organism`/`omega`/`promotion_pipeline`; without one, the base dict is returned unchanged

> Scope note: the dashboard's empty **Sprint / Flagship / Praxis** sections are produced by the *external* sibling generator (`praxis-portfolio-generate.py`), not this script — populating those remains gated on that out-of-repo pipeline. Likewise `essays.json` adding `the-organ-chain-reset` is gated: its entries mirror the external public-process blog (the URL probe was inconclusive/403), so hand-adding risks a broken link; it should be regenerated by the sibling generator.

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Bug Fixes:
- Ensure compute_vitals no longer returns early so snapshot enrichment data is included when available.