### PR TITLE
feat(#16): Stripe webhook handler + wired "Book a consult" CTA

### DIFF
--- a/src/pages/consult.astro
+++ b/src/pages/consult.astro
@@ -56,6 +56,11 @@ import Layout from '../layouts/Layout.astro';
           </div>
         </div>
 
+        <div class="book-cta" data-reveal>
+          <button type="button" id="book-consult-btn" class="book-cta__btn">Book a consult &rarr;</button>
+          <p id="book-consult-status" class="book-cta__status" role="status" aria-live="polite"></p>
+        </div>
+
         <h2 class="ai-advisor-heading">AI Capability Advisor</h2>
         <p class="consult-intro">
           Not sure which service fits? Describe your challenge below and our AI advisor will map your needs to specific capabilities.
@@ -153,6 +158,9 @@ import Layout from '../layouts/Layout.astro';
   const CONSULT_API_BASE = (import.meta.env.PUBLIC_CONSULT_API_BASE ?? '').trim();
   const CONSULT_API_URL = CONSULT_API_BASE
     ? `${CONSULT_API_BASE.replace(/\/+$/, '')}/api/consult`
+    : null;
+  const CHECKOUT_API_URL = CONSULT_API_BASE
+    ? `${CONSULT_API_BASE.replace(/\/+$/, '')}/api/checkout`
     : null;
 
   async function callConsultApi(challenge: string, industry: string, requestId: string): Promise<RenderAnalysis> {
@@ -292,7 +300,41 @@ import Layout from '../layouts/Layout.astro';
     });
   }
 
+  function initBookCta() {
+    const btn = document.getElementById('book-consult-btn') as HTMLButtonElement | null;
+    if (!btn || btn.dataset.initialized === 'true') return;
+    btn.dataset.initialized = 'true';
+    const status = document.getElementById('book-consult-status');
+    if (!CHECKOUT_API_URL) {
+      btn.hidden = true;
+      return;
+    }
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      if (status) status.textContent = 'Opening secure checkout…';
+      try {
+        const res = await fetch(CHECKOUT_API_URL, { method: 'POST' });
+        const data = (await res.json().catch(() => null)) as { url?: string } | null;
+        if (res.ok && data?.url) {
+          window.location.href = data.url;
+          return;
+        }
+        if (status) {
+          status.textContent =
+            res.status === 503
+              ? "Online booking isn't set up yet — use the AI advisor below or reach out directly."
+              : 'Could not start checkout right now. Please try again later.';
+        }
+      } catch {
+        if (status) status.textContent = 'Could not reach checkout. Please try again later.';
+      } finally {
+        btn.disabled = false;
+      }
+    });
+  }
+
   document.addEventListener('astro:page-load', initConsultForm);
+  document.addEventListener('astro:page-load', initBookCta);
 </script>
 
 <style>
@@ -617,5 +659,42 @@ import Layout from '../layouts/Layout.astro';
     .btn-submit {
       align-self: stretch;
     }
+  }
+  .book-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-sm);
+    margin: var(--space-2xl) 0;
+    text-align: center;
+  }
+  .book-cta__btn {
+    display: inline-block;
+    background: var(--accent);
+    color: var(--bg-primary);
+    border: none;
+    padding: var(--space-sm) var(--space-2xl);
+    border-radius: var(--radius-md);
+    font-family: var(--font-heading);
+    font-size: 1.05rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+      transform var(--transition-fast),
+      background var(--transition-fast);
+  }
+  .book-cta__btn:hover:not(:disabled) {
+    transform: translateY(-2px);
+    background: var(--accent-hover);
+  }
+  .book-cta__btn:disabled {
+    opacity: 0.6;
+    cursor: progress;
+  }
+  .book-cta__status {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    min-height: 1.2em;
   }
 </style>

--- a/workers/consult-api/src/index.ts
+++ b/workers/consult-api/src/index.ts
@@ -7,6 +7,7 @@ interface Env {
 	// Commerce (Stripe) — checkout is inert until both are set as secrets.
 	STRIPE_SECRET_KEY?: string;
 	STRIPE_PRICE_ID?: string;
+	STRIPE_WEBHOOK_SECRET?: string;
 	SITE_URL?: string;
 }
 
@@ -322,6 +323,74 @@ async function handleCheckout(request: Request, env: Env, corsHeaders: Headers):
 	}
 }
 
+async function verifyStripeSignature(
+	payload: string,
+	sigHeader: string,
+	secret: string,
+): Promise<boolean> {
+	// Stripe-Signature header: "t=<ts>,v1=<hex hmac>[,v1=...]"
+	const parts: Record<string, string> = {};
+	for (const seg of sigHeader.split(',')) {
+		const idx = seg.indexOf('=');
+		if (idx > 0) parts[seg.slice(0, idx)] = seg.slice(idx + 1);
+	}
+	const t = parts.t;
+	const v1 = parts.v1;
+	if (!t || !v1) return false;
+	const key = await crypto.subtle.importKey(
+		'raw',
+		new TextEncoder().encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign'],
+	);
+	const mac = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`${t}.${payload}`));
+	const expected = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, '0')).join('');
+	// Constant-time comparison.
+	if (expected.length !== v1.length) return false;
+	let diff = 0;
+	for (let i = 0; i < expected.length; i++) diff |= expected.charCodeAt(i) ^ v1.charCodeAt(i);
+	return diff === 0;
+}
+
+async function handleStripeWebhook(
+	request: Request,
+	env: Env,
+	corsHeaders: Headers,
+): Promise<Response> {
+	if (!env.STRIPE_WEBHOOK_SECRET) {
+		return jsonResponse(
+			{ ok: false, code: 'NOT_CONFIGURED', message: 'Webhook is not configured.' },
+			503,
+			corsHeaders,
+		);
+	}
+	const sig = request.headers.get('Stripe-Signature');
+	const payload = await request.text();
+	if (!sig || !(await verifyStripeSignature(payload, sig, env.STRIPE_WEBHOOK_SECRET))) {
+		return jsonResponse(
+			{ ok: false, code: 'BAD_SIGNATURE', message: 'Invalid signature.' },
+			400,
+			corsHeaders,
+		);
+	}
+	try {
+		const event = JSON.parse(payload) as { type?: string; data?: { object?: { id?: string } } };
+		if (event.type === 'checkout.session.completed') {
+			// Fulfillment hook: the session completed. Persisting to D1 or
+			// notifying would go here; for now we acknowledge receipt.
+			console.log('Stripe checkout.session.completed:', event.data?.object?.id ?? 'unknown');
+		}
+		return jsonResponse({ ok: true, received: true }, 200, corsHeaders);
+	} catch {
+		return jsonResponse(
+			{ ok: false, code: 'BAD_INPUT', message: 'Invalid webhook payload.' },
+			400,
+			corsHeaders,
+		);
+	}
+}
+
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		const origin = request.headers.get('Origin');
@@ -338,6 +407,10 @@ export default {
 
 		if (request.method === 'POST' && url.pathname === '/api/checkout') {
 			return handleCheckout(request, env, corsHeaders);
+		}
+
+		if (request.method === 'POST' && url.pathname === '/api/stripe-webhook') {
+			return handleStripeWebhook(request, env, corsHeaders);
 		}
 
 		if (request.method !== 'POST' || url.pathname !== '/api/consult') {


### PR DESCRIPTION
More #16 code, per your call.

- **Worker `POST /api/stripe-webhook`** — verifies the `Stripe-Signature` via Web Crypto HMAC-SHA256 (constant-time compare) and acknowledges `checkout.session.completed`. `503 NOT_CONFIGURED` until `STRIPE_WEBHOOK_SECRET` is set; `400` on bad/missing signature. Added the env field.
- **`consult.astro` "Book a consult" CTA** — POSTs to `/api/checkout`, redirects to the returned Stripe URL. Degrades gracefully: shows a status message on `503` (checkout unconfigured) and hides itself if no consult API base is set.

This connects the Organ III product to the gateway (a #16 acceptance item). What still requires **you**: provision Stripe (secret + price + webhook endpoint), then verify a **live transaction** and update `omega.json #11`.

## Test plan
- [x] `npm run lint` / `typecheck:strict` — clean / 0 hints
- [x] `npm run build` — CTA renders on `/consult`
- [x] worker `esbuild --bundle` + contract tests — clean / 6/6
- [ ] Stripe paths not runtime-verified (no Cloudflare runtime; worker deploy-on-demand) — validate with `wrangler dev` + test keys.

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Add a Stripe webhook endpoint and wire the consult booking CTA to Stripe checkout.

New Features:
- Introduce a client-side "Book a consult" call-to-action on the consult page that initiates a Stripe checkout session and redirects to the hosted checkout URL.
- Add a Stripe webhook handler endpoint that validates signatures and acknowledges checkout.session.completed events.

Enhancements:
- Improve consult page UX with inline status messaging and styling for the booking CTA, including graceful degradation when checkout is not configured.