### PR TITLE
feat(#53): GitHub Sponsors + Stripe Payment Link support CTAs

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 import { base } from '../utils/paths';
+import SupportBlock from './SupportBlock.astro';
 
 const year = new Date().getFullYear();
 ---
@@ -17,6 +18,7 @@ const year = new Date().getFullYear();
       <span class="footer__sep" aria-hidden="true">/</span>
       <a href="https://stakeholder-portal-ten.vercel.app/?prism=portfolio.footer" target="_blank" rel="noopener noreferrer">Intelligence</a>
     </div>
+    <SupportBlock />
     <div class="footer__right">
       <button class="theme-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
         <svg class="theme-icon theme-icon--sun" width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/src/components/SupportBlock.astro
+++ b/src/components/SupportBlock.astro
@@ -1,0 +1,74 @@
+---
+// Support CTAs for issue #53 (revenue_status + MRR).
+// Inert until the operator supplies the URLs via env:
+//   PUBLIC_SPONSORS_URL         — GitHub Sponsors page (recurring / MRR)
+//   PUBLIC_SUPPORT_PAYMENT_URL  — Stripe Payment Link (one-time / revenue_status)
+const sponsorsUrl = import.meta.env.PUBLIC_SPONSORS_URL?.trim();
+const supportPaymentUrl = import.meta.env.PUBLIC_SUPPORT_PAYMENT_URL?.trim();
+const hasAny = Boolean(sponsorsUrl || supportPaymentUrl);
+---
+
+{
+  hasAny && (
+    <div class="support-block">
+      <span class="support-block__label">Support this work</span>
+      {sponsorsUrl && (
+        <a
+          class="support-block__btn support-block__btn--sponsor"
+          href={sponsorsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span aria-hidden="true">&hearts;</span> Sponsor
+        </a>
+      )}
+      {supportPaymentUrl && (
+        <a
+          class="support-block__btn"
+          href={supportPaymentUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          One-time gift
+        </a>
+      )}
+    </div>
+  )
+}
+
+<style>
+  .support-block {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    margin-top: var(--space-md);
+  }
+  .support-block__label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+  .support-block__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-decoration: none;
+    padding: var(--space-2xs) var(--space-sm);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    transition:
+      border-color var(--transition-fast),
+      color var(--transition-fast);
+  }
+  .support-block__btn:hover {
+    border-color: var(--accent);
+    color: var(--accent-text);
+  }
+  .support-block__btn--sponsor:hover {
+    border-color: var(--accent-hover);
+    color: var(--accent-hover);
+  }
+</style>

--- a/src/components/SupportBlock.astro
+++ b/src/components/SupportBlock.astro
@@ -3,6 +3,9 @@
 // Inert until the operator supplies the URLs via env:
 //   PUBLIC_SPONSORS_URL         — GitHub Sponsors page (recurring / MRR)
 //   PUBLIC_SUPPORT_PAYMENT_URL  — Stripe Payment Link (one-time / revenue_status)
+
+export type Props = {};
+
 const sponsorsUrl = import.meta.env.PUBLIC_SPONSORS_URL?.trim();
 const supportPaymentUrl = import.meta.env.PUBLIC_SUPPORT_PAYMENT_URL?.trim();
 const hasAny = Boolean(sponsorsUrl || supportPaymentUrl);
@@ -42,7 +45,6 @@ const hasAny = Boolean(sponsorsUrl || supportPaymentUrl);
     align-items: center;
     flex-wrap: wrap;
     gap: var(--space-sm);
-    margin-top: var(--space-md);
   }
   .support-block__label {
     font-size: 0.8rem;
@@ -66,9 +68,11 @@ const hasAny = Boolean(sponsorsUrl || supportPaymentUrl);
   .support-block__btn:hover {
     border-color: var(--accent);
     color: var(--accent-text);
+    opacity: 1;
   }
   .support-block__btn--sponsor:hover {
     border-color: var(--accent-hover);
     color: var(--accent-hover);
+    opacity: 1;
   }
 </style>


### PR DESCRIPTION
More code for #53 (revenue + MRR items), per your call.

Adds a `SupportBlock` component (footer) wiring the two "Immediate" revenue items from #53:
- **GitHub Sponsors** link (recurring / MRR) via `PUBLIC_SPONSORS_URL`
- **Stripe Payment Link** (one-time / `revenue_status`) via `PUBLIC_SUPPORT_PAYMENT_URL`

**Inert by default** — renders nothing until the env URLs are set, so no broken links ship. Set the two `PUBLIC_` vars in the deploy environment to activate.

What still needs **you** (the real-world part of #53): create the Sponsors tiers + the Stripe Payment Link, then the outreach (Reddit/Dev.to/HN posts, recruiting testers, CFPs).

## Test plan
- [x] `npm run lint` / `typecheck:strict` — clean / 0 hints
- [x] `npm run build` — block renders nothing while envs unset (0 pages); footer unaffected

https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW9DnyVijUNmUJ4qMfgpHn)_

## Summary by Sourcery

Add a configurable support call-to-action block to the site footer that surfaces external funding links when provided via environment variables.

New Features:
- Introduce a SupportBlock footer component that displays GitHub Sponsors and one-time payment links based on environment configuration.

Enhancements:
- Integrate the SupportBlock component into the existing footer layout without affecting the footer when no support URLs are configured.