### PR TITLE
fix: dispatch CI deploy after refresh-data pushes to main (live-site parity)

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout
@@ -66,13 +67,26 @@ jobs:
         run: npm run sync:github-pages
 
       - name: Commit and push
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/data/system-metrics.json src/data/vitals.json src/data/landing.json src/data/github-pages.json
           if git diff --staged --quiet; then
             echo "No data changes"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: auto-refresh system data and github pages index"
             git push
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # Commits pushed with the workflow-provided GITHUB_TOKEN do NOT trigger
+      # push-event workflows, so CI (build-and-deploy) never runs for the data
+      # commit and the live Pages site lags main until the next human push.
+      # workflow_dispatch is exempt from that suppression, so dispatch CI here.
+      - name: Trigger CI deploy for the data commit
+        if: steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci.yml --ref main


### PR DESCRIPTION
## Summary
- Root cause of the live-site-lags-main parity bug: `refresh-data.yml` pushes its daily data commit to main using the workflow-provided `GITHUB_TOKEN`, and GitHub suppresses `push`-event workflow triggers for commits made with that token. `ci.yml` (build-and-deploy → Pages) therefore never runs on the data commit, so the deployed site lags main until the next human push.
- Fix: after a successful data push, explicitly dispatch `ci.yml` on `main` via `gh workflow run` (`workflow_dispatch` is exempt from the GITHUB_TOKEN suppression). Adds `actions: write` to the job permissions and a `pushed` output on the commit step so the dispatch only fires when a commit actually landed.

## Test plan
- [x] YAML validated locally
- [ ] After merge: `gh workflow run refresh-data.yml` and confirm a follow-on `CI` run appears on main and Pages redeploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure the daily data refresh workflow triggers the main CI deploy after pushing updated data to main.

Build:
- Grant the refresh-data workflow permission to invoke other GitHub Actions workflows.

CI:
- Trigger the main CI deploy workflow via workflow_dispatch from refresh-data only when a data commit is actually pushed, restoring live-site parity after automated data updates.