### PR TITLE
feat: arm funding rails (Sponsors + payrail)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [4444J99]
+custom: ["https://payrail.ivixivi.workers.dev/pay"]

--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ If `PUBLIC_CONSULT_API_BASE` is not set, the consult page still works using dete
 - [Security Policy](.github/SECURITY.md)
 - [Support](.github/SUPPORT.md)
 
+---
+
+## 💰 Support & Funding
+
+Enjoying the work? Support development through:
+
+- **[GitHub Sponsors](https://github.com/sponsors/4444J99)** — Direct recurring support
+- **[Payrail](https://payrail.ivixivi.workers.dev/pay)** — One-time or flexible contributions
+
+Your support fuels the ORGANVM ecosystem and keeps these tools free and open.
+
 ## ⚖️ License
 
 Distributed under the MIT License. See `LICENSE` for more information.


### PR DESCRIPTION
Arms GitHub Sponsors and Payrail funding rails.

- Added .github/FUNDING.yml enabling GitHub Sponsors (github: [4444J99]) with custom link to payrail pay page
- Updated README with Support & Funding section

## Summary by Sourcery

Add project funding configuration and documentation for supporting development via GitHub Sponsors and Payrail.

New Features:
- Introduce GitHub Sponsors and Payrail as official funding options for the project.

Documentation:
- Document Support & Funding options in the README, including links to GitHub Sponsors and Payrail.