### PR TITLE
Address technical debt: base-path drift + test hermeticity

### DIFF
--- a/scripts/__tests__/check-policy-change-governance.test.ts
+++ b/scripts/__tests__/check-policy-change-governance.test.ts
@@ -44,6 +44,10 @@ function initializeRepo(): { dir: string; baseSha: string; headSha: string } {
 	git(dir, 'init -q');
 	git(dir, 'config user.email "test@example.com"');
 	git(dir, 'config user.name "Test Runner"');
+	// Keep the fixture hermetic: never inherit ambient commit/tag signing config,
+	// which would make these commits fail in environments that enforce signing.
+	git(dir, 'config commit.gpgsign false');
+	git(dir, 'config tag.gpgsign false');
 	git(dir, 'add .');
 	git(dir, 'commit -m "base" --quiet');
 	const baseSha = git(dir, 'rev-parse HEAD');

--- a/src/components/charts/organ-navigator-chart.ts
+++ b/src/components/charts/organ-navigator-chart.ts
@@ -1,4 +1,5 @@
 import * as d3 from 'd3';
+import { base } from '../../utils/paths';
 import { getChartTheme } from './chart-theme';
 import { createTooltip } from './chart-utils';
 
@@ -225,9 +226,6 @@ export default function organNavigatorChart(container: HTMLElement, data: Record
 
 		// Click project → navigate
 		projectNodes.on('click', (_event: MouseEvent, p: ProjectNode) => {
-			const base =
-				document.querySelector<HTMLAnchorElement>('.header__logo')?.getAttribute('href') ||
-				'/portfolio/';
 			window.location.href = `${base}projects/${p.slug}/`;
 		});
 


### PR DESCRIPTION
## Summary

Audited the codebase for concrete technical debt and shipped two verified fixes. A third change (an Astro markdown deprecation migration) was attempted, investigated deeply, found to be a regression, and **reverted** — see the note below.

### 1. Base-path drift in organ navigator (`c7f9a46`)
`organ-navigator-chart.ts` queried the header logo `href` and fell back to a hardcoded `'/portfolio/'` string. Now imports `base` from `src/utils/paths` like every other dynamic-URL consumer, removing a base-path drift point (a CLAUDE.md invariant).

### 2. Hermetic governance test (`c5abbb1`)
`check-policy-change-governance.test.ts` created temporary git repos that inherited ambient commit/tag signing config, causing failures in signing-enforced environments. The fixture now disables signing locally so it is self-contained.

## Reverted: markdown deprecation migration

I initially migrated `markdown.rehypePlugins` → `markdown.processor: unified({...})` to silence Astro 6's deprecation warning. Two review bots flagged it; I investigated against the installed Astro 6.4.5 / `@astrojs/markdown-remark` 7.2.0 source and found:

- The bots' stated reasons were **wrong**: `markdown.processor` *is* a valid, schema-validated option (`schemas/base.js:255`, consumed in `content-layer.js:110`, `vite-plugin-markdown/index.js:64`), and the exported `unified` *does* accept arguments (`processor.js:1` — it's a custom Astro factory, not the standard `unified` package).
- But the bots' **conclusion was correct**, for a different reason: the essays are **`.mdx`**, and `@astrojs/mdx@5.0.6` honors the legacy `markdown.rehypePlugins` field but **not** the `processor` form. Verified empirically (post-processor disabled): legacy config scores essays via the pipeline (3402 `data-shibui-c`, 457 `shibui-term`); the processor form scores **0**. The full builds only looked identical because the `astro:build:done` post-processor silently annotated the unscored essays as a fallback (which also explains the site-wide serialization shift).

Since the migration moved essay annotation off the markdown pipeline onto a fallback, it is a regression. Reverted it and removed the now-unneeded `@astrojs/markdown-remark` dependency. The deprecation warning remains (advisory only — "removed in a future major"); a correct migration is deferred until `@astrojs/mdx` supports the processor API.

## Quality gates
- `npm run preflight` — passes, 324 tests green
- `npm run test:a11y` — 104 pages, 0 critical / 0 serious violations
- Essay shibui-lens annotation verified intact via the markdown pipeline (3491/463 markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Address technical debt by fixing base-path handling in the organ navigator chart and making the governance policy-change test hermetic to signing configuration.

Bug Fixes:
- Align organ navigator navigation URLs with the shared base-path utility to prevent hardcoded path drift.
- Disable git commit and tag signing in the governance policy-change test fixture so it no longer fails in signing-enforced environments.