### PR TITLE
[limen GEN-organvm-portfolio-typing-0624] Tighten types in organvm/portfolio

### DIFF
--- a/src/components/charts/chart-loader.ts
+++ b/src/components/charts/chart-loader.ts
@@ -1,3 +1,5 @@
+type ChartPayload = Record<string, unknown> | unknown[];
+
 const chartModules = {
 	'organ-bar': () => import('./organ-bar-chart'),
 	'classification-donut': () => import('./classification-donut-chart'),
@@ -7,7 +9,7 @@ const chartModules = {
 	'praxis-sparklines': () => import('./praxis-sparklines-chart'),
 	'flagship-stacked': () => import('./flagship-stacked-chart'),
 	'organ-navigator': () => import('./organ-navigator-chart'),
-} as const;
+};
 
 type ChartId = keyof typeof chartModules;
 
@@ -23,16 +25,20 @@ function isChartId(value: string): value is ChartId {
 	return value in chartModules;
 }
 
-function parseChartPayload(raw: string | undefined, chartId: string): unknown {
+function parseChartPayload(raw: string | undefined, chartId: string): ChartPayload {
 	try {
-		return JSON.parse(raw ?? '{}') as unknown;
+		const parsed = JSON.parse(raw ?? '{}');
+		if (Array.isArray(parsed) || (parsed !== null && typeof parsed === 'object')) {
+			return parsed;
+		}
+		return {};
 	} catch (err) {
 		console.error('[chart]', chartId, 'invalid chart payload:', err);
 		return {};
 	}
 }
 
-function readChartData(container: HTMLElement, chartId: string): unknown {
+function readChartData(container: HTMLElement, chartId: string): ChartPayload {
 	const dataEl = container.querySelector('script[type="application/json"]');
 	if (dataEl) {
 		return parseChartPayload(dataEl.textContent ?? '{}', chartId);
@@ -52,8 +58,7 @@ function initChart(container: HTMLElement) {
 
 	chartModules[chartId]()
 		.then((mod) => {
-			const init = mod.default as (host: HTMLElement, payload: unknown) => void;
-			init(container, data);
+			(mod.default as (host: HTMLElement, payload: unknown) => void)(container, data);
 		})
 		.catch((err) => {
 			console.error('[chart]', chartId, 'load error:', err);

--- a/src/components/galaxy/OmegaGalaxy.astro
+++ b/src/components/galaxy/OmegaGalaxy.astro
@@ -29,7 +29,7 @@ const projects = projectCatalog.map((p) => ({
   </div>
 </div>
 
-<script>
+  <script>
   import * as THREE from 'three';
   import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
@@ -40,6 +40,26 @@ const projects = projectCatalog.map((p) => ({
     tags: string[];
     summary: string;
     color: string;
+  }
+
+  function isGalaxyProject(value: unknown): value is GalaxyProject {
+    if (!value || typeof value !== 'object') return false;
+    const project = value as Record<string, unknown>;
+    return (
+      typeof project.slug === 'string' &&
+      typeof project.title === 'string' &&
+      typeof project.organ === 'string' &&
+      typeof project.summary === 'string' &&
+      typeof project.color === 'string' &&
+      Array.isArray(project.tags) &&
+      project.tags.every((tag) => typeof tag === 'string')
+    );
+  }
+
+  function parseGalaxyProjects(raw: string | null): GalaxyProject[] {
+    const parsed = JSON.parse(raw || '[]');
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isGalaxyProject);
   }
 
   function createGlowTexture(color: string) {
@@ -68,7 +88,7 @@ const projects = projectCatalog.map((p) => ({
     const canvas = document.getElementById('omega-galaxy-canvas') as HTMLCanvasElement;
     if (!container || !canvas) return;
 
-    const projects = JSON.parse(container.dataset.projects || '[]') as GalaxyProject[];
+    const projects = parseGalaxyProjects(container.dataset.projects || null);
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const controller = new AbortController();
     let rafId = 0;

--- a/src/components/sketches/SketchContainer.astro
+++ b/src/components/sketches/SketchContainer.astro
@@ -1,4 +1,6 @@
 ---
+type SketchDataAttributeValue = string | number | boolean;
+
 interface Props {
 	sketchId: string;
 	height?: string;
@@ -8,7 +10,7 @@ interface Props {
 	title?: string;
 	caption?: string;
 	dataSource?: string;
-	[key: string]: unknown;
+	[key: `data-${string}`]: SketchDataAttributeValue;
 }
 
 const {
@@ -22,7 +24,16 @@ const {
 	dataSource,
 	...rest
 } = Astro.props;
-const dataAttrs = Object.fromEntries(Object.entries(rest).filter(([k]) => k.startsWith('data-')));
+
+const dataAttrs = Object.entries(rest).reduce<Record<string, SketchDataAttributeValue>>(
+	(acc, [key, value]) => {
+		if (key.startsWith('data-')) {
+			acc[key] = value as SketchDataAttributeValue;
+		}
+		return acc;
+	},
+	{},
+);
 ---
 
 <figure class="sketch-wrapper">


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-portfolio-typing-0624`.

Eliminate the worst untyped hotspots in organvm/portfolio's most-imported module (remove `any` / add type hints / fix loose signatures). Keep the build and tests green. [auto-generated 2026-06-24 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._