### PR TITLE
fix(ci): correct GitHub Pages URL from 4444j99 to organvm throughout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Smoke test
         id: smoke
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        env:
+          DEPLOY_URL: ${{ steps.deployment.outputs.page_url }}
         run: node scripts/post-deploy-smoke.mjs
       - name: Flag failed deploy
         if: always() && steps.smoke.outcome == 'failure'

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,7 @@ import rehypeShibuiLens from './plugins/rehype-shibui-lens.mjs';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://4444j99.github.io',
+	site: 'https://organvm.github.io',
 	base: '/portfolio',
 	// Keep navigation transitions but avoid eager cross-route prefetch bursts on heavy pages.
 	prefetch: false,

--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -166,7 +166,7 @@ export async function generateOGImage(destPath, title, subtitle, accentColor = '
 								{
 									type: 'div',
 									props: {
-										children: '4444j99.github.io/portfolio',
+										children: 'organvm.github.io/portfolio',
 									},
 								},
 								{

--- a/scripts/generate-org-landing-pages.mjs
+++ b/scripts/generate-org-landing-pages.mjs
@@ -67,12 +67,12 @@ const ORGANS = {
 const HUB_LINKS = [
 	{
 		label: 'Portfolio',
-		url: 'https://4444j99.github.io/portfolio/',
+		url: 'https://organvm.github.io/portfolio/',
 		desc: 'Main portfolio hub',
 	},
 	{
 		label: 'System Directory',
-		url: 'https://4444j99.github.io/portfolio/directory/',
+		url: 'https://organvm.github.io/portfolio/directory/',
 		desc: 'All 92 sites indexed',
 	},
 	{
@@ -182,10 +182,10 @@ ${hubLinks}
     <main>
         <header>
             <h1>${escapeHtml(organ.fullName)}</h1>
-            <p>Part of the <a href="https://4444j99.github.io/portfolio/directory/" style="color:var(--primary);text-decoration:none;font-weight:600">ORGANVM eight-organ system</a></p>
+            <p>Part of the <a href="https://organvm.github.io/portfolio/directory/" style="color:var(--primary);text-decoration:none;font-weight:600">ORGANVM eight-organ system</a></p>
         </header>
         <div class="hub-banner">
-            Explore the full system: <a href="https://4444j99.github.io/portfolio/">Portfolio</a> · <a href="https://4444j99.github.io/portfolio/directory/">Directory</a> · <a href="https://organvm-v-logos.github.io/public-process/">49 Essays</a>
+            Explore the full system: <a href="https://organvm.github.io/portfolio/">Portfolio</a> · <a href="https://organvm.github.io/portfolio/directory/">Directory</a> · <a href="https://organvm-v-logos.github.io/public-process/">49 Essays</a>
         </div>
         <p class="count">${repos.length} repositories with GitHub Pages</p>
         <div class="repo-grid">

--- a/scripts/generate-qr-codes.mjs
+++ b/scripts/generate-qr-codes.mjs
@@ -8,7 +8,7 @@ const personasPath = path.join(__dirname, '../src/data/personas.json');
 const personas = JSON.parse(fs.readFileSync(personasPath, 'utf8')).personas;
 
 const OUTPUT_DIR = path.join(__dirname, '../public/qr');
-const BASE_URL = 'https://4444j99.github.io/portfolio/resume';
+const BASE_URL = 'https://organvm.github.io/portfolio/resume';
 
 async function downloadQR(url, outputPath) {
 	const apiUrl = `https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(url)}&color=d4a853&bgcolor=0a0a0b`;

--- a/scripts/lighthouse-cloud.mjs
+++ b/scripts/lighthouse-cloud.mjs
@@ -13,7 +13,7 @@
 
 import { mkdirSync, writeFileSync } from 'fs';
 
-const BASE_URL = 'https://4444j99.github.io/portfolio';
+const BASE_URL = 'https://organvm.github.io/portfolio';
 const PSI_API = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed';
 const API_KEY = process.env.PSI_API_KEY || ''; // allow-secret
 

--- a/scripts/post-deploy-smoke.mjs
+++ b/scripts/post-deploy-smoke.mjs
@@ -5,7 +5,10 @@
  * Exit 0 = healthy, exit 1 = broken (triggers rollback).
  */
 
-const BASE_URL = process.env.DEPLOY_URL || 'https://4444j99.github.io/portfolio';
+const BASE_URL = (process.env.DEPLOY_URL || 'https://organvm.github.io/portfolio').replace(
+	/\/$/,
+	'',
+);
 
 const CHECKS = [
 	{ path: '/', expect: { status: 200, bodyContains: 'Anthony' } },

--- a/scripts/syndicate-essays.mjs
+++ b/scripts/syndicate-essays.mjs
@@ -22,7 +22,7 @@ import { basename, join, resolve } from 'node:path';
 const ROOT = resolve(import.meta.dirname, '..');
 const LOGOS_DIR = join(ROOT, 'src', 'content', 'logos');
 const OUT_DIR = join(ROOT, 'dist-syndication', 'devto');
-const CANONICAL_BASE = 'https://4444j99.github.io/portfolio/logos';
+const CANONICAL_BASE = 'https://organvm.github.io/portfolio/logos';
 
 /**
  * Parse YAML-ish frontmatter from a markdown file.

--- a/scripts/update-org-profile-readmes.mjs
+++ b/scripts/update-org-profile-readmes.mjs
@@ -39,7 +39,7 @@ const HUB_FOOTER = [
 	'',
 	'**Explore the System**',
 	'',
-	'[Portfolio](https://4444j99.github.io/portfolio/) · [System Directory](https://4444j99.github.io/portfolio/directory/) · [49 Essays](https://organvm-v-logos.github.io/public-process/) · [Knowledge Base](https://organvm-i-theoria.github.io/my-knowledge-base/) · [Consult](https://4444j99.github.io/portfolio/consult/)',
+	'[Portfolio](https://organvm.github.io/portfolio/) · [System Directory](https://organvm.github.io/portfolio/directory/) · [49 Essays](https://organvm-v-logos.github.io/public-process/) · [Knowledge Base](https://organvm-i-theoria.github.io/my-knowledge-base/) · [Consult](https://organvm.github.io/portfolio/consult/)',
 	'',
 	'</div>',
 	'<!-- PORTFOLIO-HUB-END -->',

--- a/scripts/update-project-readmes.mjs
+++ b/scripts/update-project-readmes.mjs
@@ -33,7 +33,7 @@ if (existsSync(projectPagesDir)) {
 	for (const file of readdirSync(projectPagesDir)) {
 		if (file.endsWith('.astro')) {
 			const slug = file.replace('.astro', '');
-			CASE_STUDY_MAP[slug] = `https://4444j99.github.io/portfolio/projects/${slug}/`;
+			CASE_STUDY_MAP[slug] = `https://organvm.github.io/portfolio/projects/${slug}/`;
 		}
 	}
 }
@@ -73,8 +73,8 @@ function makeFooter(owner, repoName) {
 	const caseStudy = findCaseStudy(repoName);
 
 	const links = [
-		`[Portfolio](https://4444j99.github.io/portfolio/)`,
-		`[System Directory](https://4444j99.github.io/portfolio/directory/)`,
+		`[Portfolio](https://organvm.github.io/portfolio/)`,
+		`[System Directory](https://organvm.github.io/portfolio/directory/)`,
 		`[ORGAN ${organName}](${organUrl})`,
 	];
 
@@ -87,7 +87,7 @@ function makeFooter(owner, repoName) {
 		'',
 		'---',
 		'',
-		`<sub>${links.join(' \u00B7 ')} \u00B7 Part of the <a href="https://4444j99.github.io/portfolio/directory/">ORGANVM eight-organ system</a></sub>`,
+		`<sub>${links.join(' \u00B7 ')} \u00B7 Part of the <a href="https://organvm.github.io/portfolio/directory/">ORGANVM eight-organ system</a></sub>`,
 		'',
 		'<!-- SYSTEM-NAV-END -->',
 	].join('\n');

--- a/scripts/validate-build.mjs
+++ b/scripts/validate-build.mjs
@@ -11,7 +11,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 const DIST = resolve('dist');
-const SITE_BASE = 'https://4444j99.github.io/portfolio/';
+const SITE_BASE = 'https://organvm.github.io/portfolio/';
 let exitCode = 0;
 
 if (!existsSync(DIST)) {

--- a/src/components/__tests__/feed-output.test.ts
+++ b/src/components/__tests__/feed-output.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 const DIST = resolve(process.cwd(), 'dist');
 const describeBuiltOutput = existsSync(DIST) ? describe : describe.skip;
 const FEED = resolve(DIST, 'feed.xml');
-const SITE_BASE = 'https://4444j99.github.io/portfolio/';
+const SITE_BASE = 'https://organvm.github.io/portfolio/';
 
 function variants(relativePath: string): string[] {
 	const normalized = relativePath.replace(/^\/+/, '');

--- a/src/components/head/SchemaOrg.astro
+++ b/src/components/head/SchemaOrg.astro
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const { description, ogImage, project } = Astro.props;
-const canonicalURL = new URL(Astro.url.pathname, 'https://4444j99.github.io').href;
+const canonicalURL = new URL(Astro.url.pathname, 'https://organvm.github.io').href;
 
 const jsonLd = project
 	? {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,7 +50,7 @@ const {
 	keywords = [],
 	shibuiFloor,
 } = Astro.props;
-const canonicalURL = new URL(Astro.url.pathname, 'https://4444j99.github.io').href;
+const canonicalURL = new URL(Astro.url.pathname, 'https://organvm.github.io').href;
 ---
 
 <!doctype html>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -26,7 +26,7 @@ import { base } from '../utils/paths';
         <h1>About</h1>
         <span class="sr-only p-name">Anthony James Padavano</span>
         <span class="sr-only p-job-title">Creative Technologist</span>
-        <a class="sr-only u-url" href="https://4444j99.github.io/portfolio/">Portfolio</a>
+        <a class="sr-only u-url" href="https://organvm.github.io/portfolio/">Portfolio</a>
         <span class="sr-only p-locality">New York City</span>
 
         <section class="about__bio prose" data-reveal>

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -11,7 +11,7 @@ interface EssayItem {
 }
 
 export function GET(context: APIContext) {
-	const siteBase = 'https://4444j99.github.io/portfolio/';
+	const siteBase = 'https://organvm.github.io/portfolio/';
 	const fallbackProjectDate = new Date('2026-02-10T00:00:00.000Z');
 	const indexSlugs = new Set(projectIndex.map((p) => p.slug));
 

--- a/src/pages/github-pages.xml.ts
+++ b/src/pages/github-pages.xml.ts
@@ -21,7 +21,7 @@ const directory = pagesDirectory as {
 };
 
 export function GET(context: APIContext) {
-	const siteBase = 'https://4444j99.github.io/portfolio/';
+	const siteBase = 'https://organvm.github.io/portfolio/';
 	const fallbackDate = Number.isFinite(Date.parse(directory.generatedAt))
 		? new Date(directory.generatedAt)
 		: new Date();

--- a/src/pages/resume/polymath.astro
+++ b/src/pages/resume/polymath.astro
@@ -291,7 +291,7 @@ const wordsK = Math.floor(vitals.logos.words / 1000);
         <section class="resume__section">
           <h2>Links</h2>
           <ul class="resume__links">
-            <li><a href={base}>Portfolio</a> — 4444j99.github.io/portfolio</li>
+            <li><a href={base}>Portfolio</a> — organvm.github.io/portfolio</li>
             <li><a href="https://www.linkedin.com/in/anthony-james-padavano-98a40a186/" target="_blank" rel="noopener noreferrer">LinkedIn</a> — anthony-james-padavano</li>
             <li><a href="https://github.com/meta-organvm" target="_blank" rel="noopener noreferrer">GitHub (system)</a> — meta-organvm</li>
             <li><a href="https://github.com/4444j99" target="_blank" rel="noopener noreferrer">GitHub (personal)</a> — 4444j99</li>

--- a/src/utils/og-image.ts
+++ b/src/utils/og-image.ts
@@ -121,7 +121,7 @@ export async function generateOGImage(
 											color: '#6e6e71',
 											letterSpacing: '0.05em',
 										},
-										children: '4444j99.github.io/portfolio',
+										children: 'organvm.github.io/portfolio',
 									},
 								},
 								{

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -9,5 +9,5 @@
 /** Base path with a guaranteed trailing slash, e.g. `/portfolio/`. */
 export const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
-/** Full canonical origin + base, e.g. `https://4444j99.github.io/portfolio`. */
-export const canonicalBase = 'https://4444j99.github.io/portfolio';
+/** Full canonical origin + base, e.g. `https://organvm.github.io/portfolio`. */
+export const canonicalBase = 'https://organvm.github.io/portfolio';


### PR DESCRIPTION
## Summary

- The portfolio repo is deployed at `https://organvm.github.io/portfolio/` (confirmed via GitHub Pages API) but every config file and script hardcoded `4444j99.github.io`
- The post-deploy smoke test was hitting `https://4444j99.github.io/portfolio/` (wrong host) causing all 5 URL checks to return 404 and the CI to fail on every push to main
- Updated 20 files: `astro.config.mjs`, `src/utils/paths.ts`, `src/layouts/Layout.astro`, `src/components/head/SchemaOrg.astro`, `src/pages/feed.xml.ts`, `src/pages/github-pages.xml.ts`, OG image text, utility scripts, and the smoke test fallback URL
- Also wired `DEPLOY_URL: ${{ steps.deployment.outputs.page_url }}` into the CI workflow so the smoke test uses the actual deployment URL automatically in the future

## Test plan

- [x] `npm run lint` — passes (biome, no errors)
- [x] `npm run typecheck:strict` — 0 errors, 0 hints
- [x] `npm run test` — 272/272 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)