### PR TITLE
Tighten types in organvm/portfolio

### DIFF
--- a/src/components/charts/chart-loader.ts
+++ b/src/components/charts/chart-loader.ts
@@ -23,16 +23,16 @@ function isChartId(value: string): value is ChartId {
 	return value in chartModules;
 }
 
-function parseChartPayload(raw: string | undefined, chartId: string) {
+function parseChartPayload(raw: string | undefined, chartId: string): unknown {
 	try {
-		return JSON.parse(raw ?? '{}');
+		return JSON.parse(raw ?? '{}') as unknown;
 	} catch (err) {
 		console.error('[chart]', chartId, 'invalid chart payload:', err);
 		return {};
 	}
 }
 
-function readChartData(container: HTMLElement, chartId: string) {
+function readChartData(container: HTMLElement, chartId: string): unknown {
 	const dataEl = container.querySelector('script[type="application/json"]');
 	if (dataEl) {
 		return parseChartPayload(dataEl.textContent ?? '{}', chartId);

--- a/src/components/galaxy/OmegaGalaxy.astro
+++ b/src/components/galaxy/OmegaGalaxy.astro
@@ -33,6 +33,15 @@ const projects = projectCatalog.map((p) => ({
   import * as THREE from 'three';
   import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
+  interface GalaxyProject {
+    slug: string;
+    title: string;
+    organ: string;
+    tags: string[];
+    summary: string;
+    color: string;
+  }
+
   function createGlowTexture(color: string) {
     const canvas = document.createElement('canvas');
     canvas.width = 64;
@@ -59,7 +68,7 @@ const projects = projectCatalog.map((p) => ({
     const canvas = document.getElementById('omega-galaxy-canvas') as HTMLCanvasElement;
     if (!container || !canvas) return;
 
-    const projects = JSON.parse(container.dataset.projects || '[]');
+    const projects = JSON.parse(container.dataset.projects || '[]') as GalaxyProject[];
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const controller = new AbortController();
     let rafId = 0;
@@ -90,9 +99,9 @@ const projects = projectCatalog.map((p) => ({
     const starGeometry = new THREE.SphereGeometry(2, 16, 16);
 
     // Position Logic: Distribute organs in a spiral/spherical volume
-    const organKeys = [...new Set(projects.map((p: any) => p.organ))];
+    const organKeys = [...new Set(projects.map((p) => p.organ))];
 
-    projects.forEach((project: any) => {
+    projects.forEach((project) => {
       const organIndex = organKeys.indexOf(project.organ);
       const organAngle = (organIndex / organKeys.length) * Math.PI * 2;
       const organRadius = 150 + Math.random() * 50;
@@ -173,7 +182,7 @@ const projects = projectCatalog.map((p) => ({
       }
     }
 
-    function showRepoInfo(project: any) {
+    function showRepoInfo(project: GalaxyProject) {
       if (!infoCard || !repoTitle || !repoOrgan || !repoSummary || !repoTags || !repoLink) return;
       
       repoTitle.textContent = project.title;

--- a/src/components/galaxy/OmegaGalaxy.astro
+++ b/src/components/galaxy/OmegaGalaxy.astro
@@ -167,7 +167,7 @@ const projects = projectCatalog.map((p) => ({
       const intersects = raycaster.intersectObjects(starObjects);
 
       if (intersects.length > 0) {
-        const project = intersects[0].object.userData;
+        const project = intersects[0].object.userData as GalaxyProject;
         showRepoInfo(project);
         
         // Animate camera to star
@@ -403,4 +403,3 @@ const projects = projectCatalog.map((p) => ({
     color: var(--text-muted);
   }
 </style>
-


### PR DESCRIPTION
## Summary

- **`chart-loader.ts`**: Added explicit `: unknown` return types to `parseChartPayload` and `readChartData` so `JSON.parse`'s implicit `any` does not leak through to callers
- **`OmegaGalaxy.astro`**: Introduced a `GalaxyProject` interface for project data parsed from the DOM `data-projects` attribute, replacing three bare `: any` annotations with inferred types from the typed cast

## Test plan

- [x] `npm run typecheck:strict` — 0 hints (budget 0, phase W12)
- [x] `vitest run` — 279 tests pass, 29 skipped
- [x] `npm run lint:fix` — no fixes applied

limen task GEN-organvm-portfolio-typing-0626

🤖 Generated with [Claude Code](https://claude.com/claude-code)