### PR TITLE
[limen GEN-organvm-portfolio-ci-green-0629] Make organvm/portfolio CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
       # --- Test ---
       - name: Unit Tests
         run: npm run test:coverage
+      - name: Package Fixture Tests
+        run: npm run test:github-pages-core
       - name: Validate Build
         run: npm run validate
 


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-portfolio-ci-green-0629`.

Inspect the latest FAILING checks on organvm/portfolio's default branch, fix the root cause (lint / types / failing test / config), and confirm the checks pass. If CI is already green, add the single most valuable missing check (e.g. typecheck or test-matrix) instead. [auto-generated 2026-06-29 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._