### PR TITLE
[limen GEN-organvm-portfolio-ci-green-0630] Make organvm/portfolio CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
         env:
           PUBLIC_CONSULT_API_BASE: https://portfolio-consult-api.ivixivi.workers.dev # allow-secret
 
+      - name: Validate runtime route manifest
+        run: npm run sync:a11y-routes && npm run check:runtime-route-manifest
+
       # --- Test ---
       - name: Unit Tests
         run: npm run test:coverage


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-portfolio-ci-green-0630`.

Inspect the latest FAILING checks on organvm/portfolio's default branch, fix the root cause (lint / types / failing test / config), and confirm the checks pass. If CI is already green, add the single most valuable missing check (e.g. typecheck or test-matrix) instead. [auto-generated 2026-06-30 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._