### PR TITLE
[limen GEN-organvm-portfolio-ci-green-0701] Make organvm/portfolio CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
         run: npm run test:github-pages-core
       - name: Quality Ratchet Kit Tests
         run: npm run test:quality-ratchet-kit
+      - name: Sketch Package Tests
+        run: npm run test:sketches
       - name: Validate Build
         run: npm run validate
 


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-portfolio-ci-green-0701`.

Inspect the latest FAILING checks on organvm/portfolio's default branch, fix the root cause (lint / types / failing test / config), and confirm the checks pass. If CI is already green, add the single most valuable missing check (e.g. typecheck or test-matrix) instead. [auto-generated 2026-07-01 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._