### PR TITLE
fix: correct README URLs/count + repair Refresh System Data workflow

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -66,8 +66,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: npm run sync:github-pages
 
-      - name: Commit and push
+      - name: Commit refreshed data to a PR branch
         id: commit
+        env:
+          BRANCH: chore/auto-refresh-data
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -77,16 +79,30 @@ jobs:
             echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: auto-refresh system data and github pages index"
-            git push
+            # main is protected (required check: build-and-deploy), so a direct
+            # push is rejected (GH006). Publish to a stable bot branch instead and
+            # land it via the PR + auto-merge path below.
+            git push -f origin "HEAD:refs/heads/$BRANCH"
             echo "pushed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Commits pushed with the workflow-provided GITHUB_TOKEN do NOT trigger
-      # push-event workflows, so CI (build-and-deploy) never runs for the data
-      # commit and the live Pages site lags main until the next human push.
-      # workflow_dispatch is exempt from that suppression, so dispatch CI here.
-      - name: Trigger CI deploy for the data commit
+      # main's required build-and-deploy check must report on the PR head before it
+      # can merge, but GITHUB_TOKEN pushes do NOT trigger push/PR workflows. So open
+      # a PR and dispatch ci.yml on the branch: workflow_dispatch is exempt from that
+      # suppression, so the check runs on the head SHA, satisfies branch protection,
+      # and auto-merge lands the refresh. No branch-protection or credential change
+      # is required.
+      - name: Open PR, run CI on it, and enable auto-merge
         if: steps.commit.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run ci.yml --ref main
+          BRANCH: chore/auto-refresh-data
+        run: |
+          if ! gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "chore: auto-refresh system data" \
+              --body "Automated daily refresh of system-metrics, vitals, landing, and github-pages data. CI-gated; auto-merges when build-and-deploy is green."
+          fi
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh pr merge "$BRANCH" --auto --squash --delete-branch \
+            || echo "::warning::auto-merge could not be enabled; PR left open for review"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   <img src="public/favicon.svg" width="120" height="120" alt="ORGANVM Logo" />
   <h3>The central node of an Eight-Organ Creative-Institutional System.</h3>
   
-  [![Live Site](https://img.shields.io/badge/Live-4444j99.github.io/portfolio-00BCD4?style=for-the-badge&logo=github)](https://4444j99.github.io/portfolio/)
-  [![Quality Gates](https://github.com/4444j99/portfolio/actions/workflows/quality.yml/badge.svg?style=for-the-badge)](https://github.com/4444j99/portfolio/actions/workflows/quality.yml)
+  [![Live Site](https://img.shields.io/badge/Live-organvm.github.io/portfolio-00BCD4?style=for-the-badge&logo=github)](https://organvm.github.io/portfolio/)
+  [![CI](https://github.com/organvm/portfolio/actions/workflows/ci.yml/badge.svg?style=for-the-badge)](https://github.com/organvm/portfolio/actions/workflows/ci.yml)
   [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge)](LICENSE)
 </div>
 
@@ -13,9 +13,9 @@
 
 ## 🔭 Overview
 
-Personal portfolio site showcasing 20 project case studies, an interactive p5.js generative hero, and a live engineering dashboard. The project is organized around the **ORGANVM** system—a polymathic framework spanning 91 repositories and 8 GitHub organizations.
+Personal portfolio site showcasing 19 project case studies, an interactive p5.js generative hero, and a live engineering dashboard. The project is organized around the **ORGANVM** system—a polymathic framework spanning 91 repositories and 8 GitHub organizations.
 
-*   **Live Hub:** [4444j99.github.io/portfolio](https://4444j99.github.io/portfolio/)
+*   **Live Hub:** [organvm.github.io/portfolio](https://organvm.github.io/portfolio/)
 *   **Architecture:** [The Eight-Organ System](https://github.com/meta-organvm)
 
 ![Portfolio Preview](docs/assets/homepage-full.png)
@@ -96,7 +96,7 @@ Security ratchet checkpoints: `2026-02-21` `moderate<=5, low<=4`, `2026-02-28` `
 ### Install
 
 ```bash
-git clone https://github.com/4444j99/portfolio
+git clone https://github.com/organvm/portfolio
 cd portfolio
 npm install
 ```


### PR DESCRIPTION
Pre-flight cleanup of the portfolio (send-link for an interview).

## What & why
- **README broken URLs → 404s.** Live Site badge + Live Hub link pointed at `4444j99.github.io/portfolio`; the site actually serves from `organvm.github.io/portfolio` (verified via `gh api .../pages`). Fixed those, pointed the CI badge at the real `ci.yml` (the old one referenced a nonexistent `quality.yml` under the wrong org), and corrected the clone URL to `organvm/portfolio`. The Sponsors link (`4444J99`) is his real username — left as-is.
- **Project count drift.** README said "20 project case studies"; `src/data/projects.json` has `total_curated: 19` (19 entries) and the site already renders 19 dynamically. README → 19. (The repo *About* description still says "16 systems" — that's GitHub metadata, not in this PR; updated separately.)
- **`Refresh System Data` workflow failing daily.** Root cause: `main` is now a protected branch (required check `build-and-deploy`), so the job's direct `git push` is rejected (`GH006`). Reworked it to land the refresh via a PR on a stable bot branch and dispatch `ci.yml` on that branch — `workflow_dispatch` is exempt from the GITHUB_TOKEN push-event suppression, so `build-and-deploy` reports on the head SHA, satisfies branch protection, and auto-merge lands it. **No branch-protection or credential change required.**

## Not changed (verified, deliberately)
- Per-project `url`/status fields — checked: all 19 projects already have a `url` deep-link + `implementation_status` + `promotion_status`. Not empty; nothing to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)