### PR TITLE
fix: repair daily refresh pipeline (grant pull-requests:write)

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       actions: write
+      pull-requests: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Root cause
The **Refresh System Data** workflow has failed every day for ~2 weeks, freezing the portfolio's public metrics. Its `permissions:` block granted `contents:write` + `actions:write` but not `pull-requests:write`, so the step that opens the data-refresh PR died with:

```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

The job could push fresh data to `chore/auto-refresh-data` but never open the PR to land it — so `landing.json` froze at 2026-06-19 (sprints=0, total repos=116) while the canonical count is 149.

## Fix
Add `pull-requests:write` to the job permissions. One line. Restores the self-healing refresh loop; the next run opens + auto-merges the data PR and the public numbers correct themselves.

## Note
If the repo/org setting *Allow GitHub Actions to create and approve pull requests* is disabled, the create will still 403 even with this scope — in that case that toggle is the remaining atom. This fix is the necessary code half.

Content-neutral to the deployed site (workflow file only).