### PR TITLE
[limen GEN-organvm-portfolio-ci-green-0703] Make organvm/portfolio CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: npm run sync:github-pages
+      - name: Validate GitHub Pages data
+        run: npm run validate:github-pages
       - name: Build
         run: npm run build
         env:


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-portfolio-ci-green-0703`.

Inspect the latest FAILING checks on organvm/portfolio's default branch, fix the root cause (lint / types / failing test / config), and confirm the checks pass. If CI is already green, add the single most valuable missing check (e.g. typecheck or test-matrix) instead. [auto-generated 2026-07-03 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._