### PR TITLE
[limen GEN-organvm-portfolio-ci-green-0703] Make organvm/portfolio CI green

### DIFF
--- a/.config/playwright.smoke.config.ts
+++ b/.config/playwright.smoke.config.ts
@@ -1,5 +1,17 @@
 import { defineConfig } from '@playwright/test';
 
+const browserOverride = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+	? {
+			launchOptions: {
+				executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+			},
+		}
+	: process.env.PLAYWRIGHT_BROWSER_CHANNEL
+		? {
+				channel: process.env.PLAYWRIGHT_BROWSER_CHANNEL,
+			}
+		: {};
+
 export default defineConfig({
 	testDir: '../src/e2e',
 	testMatch: '*.smoke.spec.ts',
@@ -11,6 +23,7 @@ export default defineConfig({
 	use: {
 		baseURL: 'http://127.0.0.1:4173/portfolio/',
 		headless: true,
+		...browserOverride,
 	},
 	projects: [
 		{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: E2E Smoke Tests
         run: npm run test:e2e:smoke
+      - name: Runtime Error Telemetry
+        run: npm run test:runtime:errors
       - name: Unit Tests
         run: npm run test:coverage
       - name: Package Fixture Tests


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-portfolio-ci-green-0703`.

Inspect the latest FAILING checks on organvm/portfolio's default branch, fix the root cause (lint / types / failing test / config), and confirm the checks pass. If CI is already green, add the single most valuable missing check (e.g. typecheck or test-matrix) instead. [auto-generated 2026-07-03 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._