### PR TITLE
fix: laurel alt text tracks the v0.4 scoped claim

### DIFF
--- a/src/components/home/LaurelsBentoCell.astro
+++ b/src/components/home/LaurelsBentoCell.astro
@@ -10,7 +10,7 @@
 	<a href="https://github.com/4444J99/laurea" class="laurels-cell__frame">
 		<img
 			src="https://raw.githubusercontent.com/4444J99/laurea/main/assets/cards/hero.svg"
-			alt="Computed laurels — top 1% Python full-stack engineer, recomputed daily from live GitHub data"
+			alt="Computed laurels — top 0.1% engineering throughput and a top-1% Python full-stack output profile, recomputed daily from live GitHub data"
 			width="800"
 			height="240"
 			loading="lazy"


### PR DESCRIPTION
LAVREA v0.4 scoped the composite to an output profile; the cell's alt text still said 'engineer'. One-string change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)