### PR TITLE
heal-cifix-organvm-portfolio-175-d72efada lifecycle checkpoint

### DIFF
--- a/logs/agents/opencode.json
+++ b/logs/agents/opencode.json
@@ -1,0 +1,11 @@
+{
+  "agent": "opencode",
+  "status": "idle",
+  "accepting_tasks": true,
+  "available_tokens": 17110304,
+  "available_pct": 34.2,
+  "current_task_id": "GEN-organvm-portfolio-ci-green-0702",
+  "heartbeat": "2026-07-03T11:29:16.963629+00:00",
+  "token_usage_pct": 65.78,
+  "clock_health": "throttle"
+}


### PR DESCRIPTION
Lifecycle preservation PR opened by `scripts/worktree-pr-receipts.py`.

Purpose:
- Move a clean pushed worktree branch out of local-only debt.
- Provide an owner review surface without merging or deleting anything.

Verification performed by the helper:
- clean `git status --porcelain`
- remote/default branch fetched
- missing remote head pushed when needed

Opened as draft because lifecycle reduction is not merge authorization.