### PR TITLE
CI: cover Shibui rhetoric package tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
         run: npm run test:github-pages-core
       - name: Quality Ratchet Kit Tests
         run: npm run test:quality-ratchet-kit
+      - name: Shibui Rhetoric Tests
+        run: npm run test:shibui-rhetoric
       - name: Sketch Package Tests
         run: npm run test:sketches
       - name: Validate Build

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ npm run test:runtime:errors  # Runtime error telemetry
 # Workspace packages (Node built-in test runner, not Vitest):
 npm run test:github-pages-core
 npm run test:quality-ratchet-kit
+npm run test:shibui-rhetoric
 npm run test:sketches
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"check:github-pages-core": "node scripts/check-github-pages-core-drift.mjs",
 		"test:github-pages-core": "node --test packages/github-pages-index-core/test/core-fixtures.test.mjs",
 		"test:quality-ratchet-kit": "node --test packages/quality-ratchet-kit/test/ratchet-kit.test.mjs",
+		"test:shibui-rhetoric": "node --test packages/shibui-rhetoric/test/rhetoric.test.mjs",
 		"test:sketches": "node --test packages/sketches/test/sketches.test.mjs",
 		"sync:workspace-health": "node scripts/sync-workspace-health.mjs --output src/data/workspace-health.json",
 		"build": "npm run generate-badges && npm run sync:vitals && npm run sync:omega && npm run sync:identity && astro build && npx pagefind --site dist --glob '**/*.html'",


### PR DESCRIPTION
## Summary

- Add the root `test:shibui-rhetoric` script for the Shibui rhetoric package test suite.
- Run that script as a dedicated CI step so the package contract cannot regress silently.
- Document the check in the README verification commands.

## Verification

- `npm run test:shibui-rhetoric` — 22/22 tests passed.
- `git diff --check` — passed.

Task: `GEN-organvm-portfolio-ci-green-0709`