### PR TITLE
fix(deploy): Netlify root serves /portfolio/* assets (was unstyled raw HTML)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,8 @@
+# Netlify serves this site at the ROOT domain (4444j99-portfolio.netlify.app),
+# but the Astro build bakes in `base: '/portfolio'` for the GitHub Pages deploy
+# (organvm.github.io/portfolio/). Without this rule every asset/nav URL is emitted
+# as `/portfolio/...`, which 404s on the Netlify root and renders the site as
+# unstyled raw HTML. This rewrite (status 200, not a 3xx redirect) serves the
+# real root-level file for any `/portfolio/*` request, fixing Netlify while
+# leaving the Pages subpath deploy untouched.
+/portfolio/*  /:splat  200


### PR DESCRIPTION
**Root cause.** The Astro build bakes `base: '/portfolio'` (for the GitHub Pages deploy at organvm.github.io/portfolio/), so every asset URL is emitted as `/portfolio/_astro/…` — which **404s on the Netlify root domain** (4444j99-portfolio.netlify.app). The public surface rendered as unstyled raw HTML (DECORVM visual finding, verdict: fail).

**Fix.** `public/_redirects` → copied verbatim into `dist/` by Astro → a Netlify **200 rewrite** `/portfolio/* /:splat` serves the real root-level file. Fixes the judged Netlify surface **without touching the base config the Pages subpath deploy depends on**.

Verified: `/portfolio/_astro/*` currently returns 404 on Netlify root; index returns 200 but references subpath assets. Reversible, in-repo, no Netlify-dashboard change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)