### PR TITLE
fix: eliminate the 404 script console error on the Pages deploy

### DIFF
--- a/src/components/scripts/ClientBootstrap.astro
+++ b/src/components/scripts/ClientBootstrap.astro
@@ -1,4 +1,6 @@
 <script>
+  import { base } from '../../utils/paths';
+
   const globalScope = globalThis as typeof globalThis & {
     __portfolioBootstrapState?: { listenersAttached: boolean };
   };
@@ -20,7 +22,7 @@
   if (!bootstrapState.listenersAttached) {
     // Service worker registration — runs once on initial load
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(() => {});
+      navigator.serviceWorker.register(`${base}sw.js`).catch(() => {});
     }
 
     // Focus management for View Transitions — move focus to main content


### PR DESCRIPTION
## Root cause

`astro.config.mjs` sets `base: '/portfolio'` (no trailing slash). Astro therefore sets `import.meta.env.BASE_URL` to `'/portfolio'`. In `ClientBootstrap.astro`, the service worker was registered as:

\`\`\`js
navigator.serviceWorker.register(\`\${import.meta.env.BASE_URL}sw.js\`)
\`\`\`

This concatenates to \`/portfoliosw.js\` — a URL that does not exist on GitHub Pages — producing a 404 console error on every page load.

## One-line fix

`src/components/scripts/ClientBootstrap.astro` — import the existing `base` utility from `utils/paths.ts` (which normalises `BASE_URL` to always have a trailing slash) and use it in the registration:

\`\`\`diff
-navigator.serviceWorker.register(\`\${import.meta.env.BASE_URL}sw.js\`).catch(() => {});
+navigator.serviceWorker.register(\`\${base}sw.js\`).catch(() => {});
\`\`\`

`base` resolves to `/portfolio/`, so the registered path becomes `/portfolio/sw.js` (HTTP 200).

## Verification

- `curl -sI https://organvm.github.io/portfolio/sw.js` → 200 ✓
- `curl -sI https://organvm.github.io/portfoliosw.js` → 404 (the broken URL, now gone) ✓
- The `paths.ts` utility already exists and is used site-wide for exactly this normalisation.